### PR TITLE
support *.home.ravil.space

### DIFF
--- a/.github/workflows/pr_agent.yml
+++ b/.github/workflows/pr_agent.yml
@@ -18,3 +18,4 @@ jobs:
         env:
           OPENAI_KEY: ${{ secrets.OPENAI_TOKEN }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          github_action_config.auto_describe: "true"

--- a/k8s/apps/external/immich/http-route.yaml
+++ b/k8s/apps/external/immich/http-route.yaml
@@ -11,6 +11,7 @@ spec:
       namespace: gateway
   hostnames:
     - "immich.kube.ravil.space"
+    - "immich.home.ravil.space"
   rules:
     - backendRefs:
         - name: immich

--- a/k8s/infra/network/gateway/cert-ravilspace.yaml
+++ b/k8s/infra/network/gateway/cert-ravilspace.yaml
@@ -6,6 +6,7 @@ metadata:
 spec:
   dnsNames:
     - "*.kube.ravil.space"
+    - "*.home.ravil.space"
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/k8s/infra/network/gateway/gw-external.yaml
+++ b/k8s/infra/network/gateway/gw-external.yaml
@@ -11,7 +11,7 @@ spec:
   listeners:
     - protocol: HTTPS
       port: 443
-      name: https-gateway
+      name: https-kube-gateway
       hostname: "*.kube.ravil.space"
       tls:
         certificateRefs:
@@ -22,8 +22,8 @@ spec:
           from: All
     - protocol: HTTPS
       port: 443
-      name: https-domain-gateway
-      hostname: kube.ravil.space
+      name: https-home-gateway
+      hostname: "*.home.ravil.space"
       tls:
         certificateRefs:
           - kind: Secret


### PR DESCRIPTION
### **PR Type**
enhancement, configuration changes


___

### **Description**
- Added support for `*.home.ravil.space` by updating relevant configurations.
- Modified HTTP route to include `immich.home.ravil.space`.
- Updated certificate to include `*.home.ravil.space` DNS name.
- Renamed gateway listener names and updated hostnames to reflect new domain.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>http-route.yaml</strong><dd><code>Add new hostname to HTTP route specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/apps/external/immich/http-route.yaml

<li>Added a new hostname <code>immich.home.ravil.space</code> to the HTTP route <br>specification.<br>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/5/files#diff-02a1d14318a1cb0f15877c4673c6b4816a82cc44c8b4daa297ed92977a9d5e49">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cert-ravilspace.yaml</strong><dd><code>Include new DNS name in certificate specification</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/infra/network/gateway/cert-ravilspace.yaml

<li>Added a new DNS name <code>*.home.ravil.space</code> to the certificate <br>specification.<br>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/5/files#diff-cf4c550628cc512fc3b32d55338a6afe9f7d62adc9efe0fade198283dd45867f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>gw-external.yaml</strong><dd><code>Update gateway listener names and hostnames</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/infra/network/gateway/gw-external.yaml

<li>Renamed gateway listener names to <code>https-kube-gateway</code> and <br><code>https-home-gateway</code>.<br> <li> Updated hostname for the second listener to <code>*.home.ravil.space</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/5/files#diff-a35873582501eec40ec99bcdc0dbab1a3214c0d6bd5f482d57307299ae6bc151">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information