### PR TITLE
fix: update karakeep to new server (192.168.1.49:3003)

### DIFF
--- a/k8s/apps/external/karakeep/kustomization.yaml
+++ b/k8s/apps/external/karakeep/kustomization.yaml
@@ -1,17 +1,13 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-# Namespace resource
 resources:
   - namespace.yaml
 
-# Use our component
 components:
   - ../../../components/external-service
 
-# Service-specific patches
 patches:
-  # Update Service
   - patch: |-
       - op: replace
         path: /metadata/name
@@ -21,12 +17,11 @@ patches:
         value: karakeep
       - op: replace
         path: /spec/ports/0/port
-        value: 3000
+        value: 3003
     target:
       kind: Service
       name: service-name
 
-  # Update EndpointSlice
   - patch: |-
       - op: replace
         path: /metadata/name
@@ -39,15 +34,14 @@ patches:
         value: karakeep
       - op: replace
         path: /ports/0/port
-        value: 3000
+        value: 3003
       - op: replace
         path: /endpoints/0/addresses/0
-        value: 192.168.1.8
+        value: 192.168.1.49
     target:
       kind: EndpointSlice
       name: service-name
 
-  # Update HTTPRoute
   - patch: |-
       - op: replace
         path: /metadata/name
@@ -63,7 +57,7 @@ patches:
         value: karakeep
       - op: replace
         path: /spec/rules/0/backendRefs/0/port
-        value: 3000
+        value: 3003
     target:
       kind: HTTPRoute
       name: service-name


### PR DESCRIPTION
### **User description**
Move karakeep from old server (192.168.1.8:3000) to new Docker/Dockge setup on 192.168.1.49:3003.

Includes Pocket ID OIDC integration.


___

### **PR Type**
Enhancement


___

### **Description**
- Move Karakeep endpoint to `192.168.1.49`

- Update Service and HTTPRoute to port `3003`

- Align EndpointSlice port to `3003`


___

### Diagram Walkthrough


```mermaid
flowchart LR
  hr["HTTPRoute: karakeep.ravil.space"]
  svc["Service: karakeep (port 3003)"]
  eps["EndpointSlice: karakeep -> 192.168.1.49:3003"]
  hr -- "backendRefs name/port" --> svc
  svc -- "selects endpoints" --> eps
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Update Karakeep port and endpoint IP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/apps/external/karakeep/kustomization.yaml

<ul><li>Change Service port from <code>3000</code> to <code>3003</code><br> <li> Update EndpointSlice port to <code>3003</code><br> <li> Point EndpointSlice address to <code>192.168.1.49</code><br> <li> Update HTTPRoute backend port to <code>3003</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/34/files#diff-6d67b3b3eac552bb4263827aa51165f14614d07316ce087e453d4ac09ae13adb">+4/-10</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

