### PR TITLE
fix: update paperless IP to 192.168.1.166

### DIFF
--- a/k8s/apps/external/paperless/kustomization.yaml
+++ b/k8s/apps/external/paperless/kustomization.yaml
@@ -42,7 +42,7 @@ patches:
         value: 8000
       - op: replace
         path: /endpoints/0/addresses/0
-        value: 192.168.1.191
+        value: 192.168.1.166
     target:
       kind: EndpointSlice
       name: service-name


### PR DESCRIPTION
### **User description**
Update paperless endpoint from 192.168.1.191 to 192.168.1.166


___

### **PR Type**
Bug fix


___

### **Description**
- Update `paperless` EndpointSlice IP address


___

### Diagram Walkthrough


```mermaid
flowchart LR
  kustom["k8s/apps/external/paperless/kustomization.yaml"]
  eps["EndpointSlice `service-name`"]
  ip["Endpoint address `192.168.1.166`"]
  kustom -- "patch replaces endpoint IP" --> eps
  eps -- "routes traffic to" --> ip
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>kustomization.yaml</strong><dd><code>Update paperless EndpointSlice endpoint IP</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/apps/external/paperless/kustomization.yaml

- Replace endpoint address with `192.168.1.166`


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/36/files#diff-f0a196bdc88f73229090b936b8d07dbfd60fd186a421c76d661224a7b182ad06">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

