### PR TITLE
fix: update karakeep Glance check-url port to 3003

### DIFF
--- a/k8s/apps/internal/glance/glance.yml
+++ b/k8s/apps/internal/glance/glance.yml
@@ -43,7 +43,7 @@ pages:
                 icon: si:immich
               - title: Karakeep
                 url: https://karakeep.ravil.space
-                check-url: http://karakeep.karakeep.svc.cluster.local:3000
+                check-url: http://karakeep.karakeep.svc.cluster.local:3003
                 icon: si:keras
               - title: ChangeDetection
                 url: https://changedetection.ravil.space


### PR DESCRIPTION
### **User description**
Karakeep moved to port 3003 in PR #34, update Glance monitoring to match.


___

### **PR Type**
Bug fix


___

### **Description**
- Update Glance Karakeep healthcheck port


___

### Diagram Walkthrough


```mermaid
flowchart LR
  glance["Glance: dashboard checks"]
  karakeep["Karakeep: internal service endpoint"]
  glance -- "check-url hits :3003" --> karakeep
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>glance.yml</strong><dd><code>Update Karakeep Glance healthcheck port</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

k8s/apps/internal/glance/glance.yml

- Change Karakeep `check-url` from `:3000` to `:3003`


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/37/files#diff-5493bf1c5a61cf71ec4d676793945f50639169c6bd16158cde6665140cce1620">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

