### PR TITLE
feat: add compose stacks for Komodo migration

### DIFF
--- a/stacks/README.md
+++ b/stacks/README.md
@@ -1,0 +1,37 @@
+# Docker Stacks (Komodo)
+
+Compose files for services managed by [Komodo](https://komo.do).
+
+## Deployment
+
+Komodo pulls these compose files from git and deploys them automatically.
+Secrets are stored in Komodo Variables/Secrets — never in this repo.
+
+## Required Secrets in Komodo
+
+### bytestash
+- `BYTESTASH_JWT_SECRET`
+- `BYTESTASH_OIDC_CLIENT_ID`
+- `BYTESTASH_OIDC_CLIENT_SECRET`
+
+### miniflux
+- `MINIFLUX_DB_PASSWORD`
+- `MINIFLUX_ADMIN_USERNAME`
+- `MINIFLUX_ADMIN_PASSWORD`
+- `MINIFLUX_OIDC_CLIENT_ID`
+- `MINIFLUX_OIDC_CLIENT_SECRET`
+
+### karakeep
+- `KARAKEEP_NEXTAUTH_SECRET`
+- `KARAKEEP_MEILI_MASTER_KEY`
+- `KARAKEEP_OIDC_CLIENT_ID`
+- `KARAKEEP_OIDC_CLIENT_SECRET`
+- `KARAKEEP_OPENAI_API_KEY`
+
+### n8n
+- `N8N_DB_HOST`
+- `N8N_DB_PASSWORD`
+
+### your_spotify
+- `SPOTIFY_CLIENT_ID`
+- `SPOTIFY_CLIENT_SECRET`

--- a/stacks/bytestash/compose.yaml
+++ b/stacks/bytestash/compose.yaml
@@ -1,0 +1,25 @@
+services:
+  bytestash:
+    image: ghcr.io/jordan-dalby/bytestash:latest
+    restart: always
+    volumes:
+      - bytestash_data:/data/snippets
+    ports:
+      - 5000:5000
+    environment:
+      BASE_PATH: ""
+      JWT_SECRET: ${BYTESTASH_JWT_SECRET}
+      TOKEN_EXPIRY: 24h
+      ALLOW_NEW_ACCOUNTS: "false"
+      DEBUG: "true"
+      DISABLE_ACCOUNTS: "false"
+      DISABLE_INTERNAL_ACCOUNTS: "false"
+      OIDC_ENABLED: "true"
+      OIDC_DISPLAY_NAME: Pocket ID
+      OIDC_ISSUER_URL: https://pocketid.ravil.space
+      OIDC_CLIENT_ID: ${BYTESTASH_OIDC_CLIENT_ID}
+      OIDC_CLIENT_SECRET: ${BYTESTASH_OIDC_CLIENT_SECRET}
+      OIDC_SCOPES: openid profile email
+
+volumes:
+  bytestash_data:

--- a/stacks/dozzle/compose.yaml
+++ b/stacks/dozzle/compose.yaml
@@ -1,0 +1,8 @@
+services:
+  dozzle:
+    image: amir20/dozzle:latest
+    restart: always
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - 8081:8080

--- a/stacks/karakeep/compose.yaml
+++ b/stacks/karakeep/compose.yaml
@@ -1,0 +1,51 @@
+services:
+  web:
+    image: ghcr.io/karakeep-app/karakeep:release
+    container_name: karakeep
+    restart: unless-stopped
+    volumes:
+      - karakeep_data:/data
+    ports:
+      - 3003:3000
+    environment:
+      MEILI_ADDR: http://meilisearch:7700
+      BROWSER_WEB_URL: http://chrome:9222
+      DATA_DIR: /data
+      NEXTAUTH_SECRET: ${KARAKEEP_NEXTAUTH_SECRET}
+      MEILI_MASTER_KEY: ${KARAKEEP_MEILI_MASTER_KEY}
+      NEXTAUTH_URL: https://karakeep.ravil.space
+      OAUTH_PROVIDER_NAME: PocketID
+      OAUTH_CLIENT_ID: ${KARAKEEP_OIDC_CLIENT_ID}
+      OAUTH_CLIENT_SECRET: ${KARAKEEP_OIDC_CLIENT_SECRET}
+      OAUTH_WELLKNOWN_URL: https://pocketid.ravil.space/.well-known/openid-configuration
+      OAUTH_ALLOW_DANGEROUS_EMAIL_ACCOUNT_LINKING: "true"
+      OPENAI_BASE_URL: https://openrouter.ai/api/v1
+      OPENAI_API_KEY: ${KARAKEEP_OPENAI_API_KEY}
+      INFERENCE_TEXT_MODEL: meta-llama/llama-4-scout
+      INFERENCE_IMAGE_MODEL: meta-llama/llama-4-scout
+
+  chrome:
+    image: gcr.io/zenika-hub/alpine-chrome:124
+    container_name: karakeep-chrome
+    restart: unless-stopped
+    command:
+      - --no-sandbox
+      - --disable-gpu
+      - --disable-dev-shm-usage
+      - --remote-debugging-address=0.0.0.0
+      - --remote-debugging-port=9222
+      - --hide-scrollbars
+
+  meilisearch:
+    image: getmeili/meilisearch:v1.13.3
+    container_name: karakeep-meilisearch
+    restart: unless-stopped
+    environment:
+      MEILI_NO_ANALYTICS: "true"
+      MEILI_MASTER_KEY: ${KARAKEEP_MEILI_MASTER_KEY}
+    volumes:
+      - karakeep_meilisearch:/meili_data
+
+volumes:
+  karakeep_data:
+  karakeep_meilisearch:

--- a/stacks/miniflux/compose.yaml
+++ b/stacks/miniflux/compose.yaml
@@ -1,0 +1,35 @@
+services:
+  miniflux-db:
+    image: postgres:16-alpine
+    container_name: miniflux-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: miniflux
+      POSTGRES_PASSWORD: ${MINIFLUX_DB_PASSWORD}
+      POSTGRES_DB: miniflux
+    volumes:
+      - miniflux-db:/var/lib/postgresql/data
+
+  miniflux:
+    image: miniflux/miniflux:latest
+    container_name: miniflux
+    restart: unless-stopped
+    depends_on:
+      - miniflux-db
+    ports:
+      - 8070:8080
+    environment:
+      DATABASE_URL: postgres://miniflux:${MINIFLUX_DB_PASSWORD}@miniflux-db/miniflux?sslmode=disable
+      RUN_MIGRATIONS: "1"
+      CREATE_ADMIN: "1"
+      ADMIN_USERNAME: ${MINIFLUX_ADMIN_USERNAME}
+      ADMIN_PASSWORD: ${MINIFLUX_ADMIN_PASSWORD}
+      OAUTH2_PROVIDER: oidc
+      OAUTH2_CLIENT_ID: ${MINIFLUX_OIDC_CLIENT_ID}
+      OAUTH2_CLIENT_SECRET: ${MINIFLUX_OIDC_CLIENT_SECRET}
+      OAUTH2_REDIRECT_URL: https://miniflux.ravil.space/oauth2/oidc/callback
+      OAUTH2_OIDC_DISCOVERY_ENDPOINT: https://pocketid.ravil.space
+      OAUTH2_USER_CREATION: "1"
+
+volumes:
+  miniflux-db:

--- a/stacks/n8n/compose.yaml
+++ b/stacks/n8n/compose.yaml
@@ -1,0 +1,26 @@
+services:
+  n8n:
+    image: docker.n8n.io/n8nio/n8n:latest
+    container_name: n8n
+    restart: always
+    ports:
+      - 5678:5678
+    environment:
+      DB_TYPE: postgresdb
+      DB_POSTGRESDB_DATABASE: n8n
+      DB_POSTGRESDB_HOST: ${N8N_DB_HOST}
+      DB_POSTGRESDB_PORT: "5432"
+      DB_POSTGRESDB_USER: ravilushqa
+      DB_POSTGRESDB_PASSWORD: ${N8N_DB_PASSWORD}
+      DB_POSTGRESDB_SCHEMA: public
+      DB_POSTGRESDB_SSL_REJECT_UNAUTHORIZED: "false"
+      DB_POSTGRESDB_SSL_MODE: require
+      N8N_HOST: n8n.ravil.space
+      N8N_PROTOCOL: https
+      WEBHOOK_URL: https://n8n.ravil.space
+      GENERIC_TIMEZONE: Europe/Berlin
+    volumes:
+      - n8n_data:/home/node/.n8n
+
+volumes:
+  n8n_data:

--- a/stacks/nextflux/compose.yaml
+++ b/stacks/nextflux/compose.yaml
@@ -1,0 +1,7 @@
+services:
+  nextflux:
+    image: electh/nextflux:latest
+    container_name: nextflux
+    restart: unless-stopped
+    ports:
+      - 8071:3000

--- a/stacks/rsshub/compose.yaml
+++ b/stacks/rsshub/compose.yaml
@@ -1,0 +1,10 @@
+services:
+  rsshub:
+    image: diygod/rsshub:latest
+    container_name: rsshub
+    restart: unless-stopped
+    ports:
+      - 1200:1200
+    environment:
+      NODE_ENV: production
+      CACHE_TYPE: memory

--- a/stacks/s-pdf/compose.yaml
+++ b/stacks/s-pdf/compose.yaml
@@ -1,0 +1,20 @@
+services:
+  s-pdf:
+    image: frooodle/s-pdf:latest
+    container_name: stirling-pdf
+    restart: always
+    ports:
+      - 8080:8080
+    volumes:
+      - trainingData:/usr/share/tessdata
+      - extraConfigs:/configs
+      - logs:/logs
+    environment:
+      DOCKER_ENABLE_SECURITY: "false"
+      INSTALL_BOOK_AND_ADVANCED_HTML_OPS: "false"
+      LANGS: en_GB
+
+volumes:
+  trainingData:
+  extraConfigs:
+  logs:

--- a/stacks/your_spotify/compose.yaml
+++ b/stacks/your_spotify/compose.yaml
@@ -1,0 +1,31 @@
+services:
+  server:
+    image: yooooomi/your_spotify_server
+    restart: always
+    ports:
+      - 8082:8080
+    depends_on:
+      - mongo
+    environment:
+      API_ENDPOINT: https://spotify-server.ravil.space
+      CLIENT_ENDPOINT: https://spotify.ravil.space
+      SPOTIFY_PUBLIC: ${SPOTIFY_CLIENT_ID}
+      SPOTIFY_SECRET: ${SPOTIFY_CLIENT_SECRET}
+
+  mongo:
+    container_name: your-spotify-mongo
+    restart: always
+    image: mongo:6
+    volumes:
+      - spotify_db:/data/db
+
+  web:
+    image: yooooomi/your_spotify_client
+    restart: always
+    ports:
+      - 3000:3000
+    environment:
+      API_ENDPOINT: https://spotify-server.ravil.space
+
+volumes:
+  spotify_db:


### PR DESCRIPTION
### **User description**
Migrate Docker compose files from Dockge (.49) to git-managed stacks for Komodo (.166).

## Changes
- Added `stacks/` directory with 9 compose files
- Replaced hardcoded secrets with `${VARIABLE}` interpolation for Komodo
- Added README with list of required Komodo secrets

## Stacks
- bytestash, dozzle, miniflux, karakeep, n8n, nextflux, rsshub, s-pdf, your_spotify

## Next steps
1. Configure secrets in Komodo UI
2. Point Komodo to this repo
3. Deploy stacks on .166
4. Migrate data (miniflux postgres, karakeep meilisearch, your_spotify mongo)
5. Switch DNS


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Add Komodo-managed Docker compose stacks

- Parameterize secrets via Komodo variables

- Document required secrets per service


___

### Diagram Walkthrough


```mermaid
flowchart LR
  repo["Git repo stacks/ directory"]
  komodo["Komodo (pulls from git)"]
  secrets["Komodo Variables/Secrets"]
  compose["Compose files (services)"]
  services["Deployed containers"]
  repo -- "contains" --> compose
  komodo -- "pulls" --> repo
  secrets -- "interpolates into" --> compose
  komodo -- "deploys" --> services
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Document Komodo stacks and required secrets</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-dfa1844449b98c635700c7a2ba0f31674250cd99029579ca041e2a749d542b48">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td><strong>compose.yaml</strong><dd><code>Add Bytestash stack with OIDC variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-cd0ef83352f5d24633db1be1dfecf7eee18fb34739162353d69877d7242c1247">+25/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add Dozzle log viewer stack</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-07dd566390a1769c4d660ff35fc9683bde71a36020d2096d37d13ee67dd16b1c">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add Karakeep with Chrome and Meilisearch</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-0df42c54e08f247720c6f55c7c700757b0abf5a0a7a88cf6edd5c025d4cd9dee">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add Miniflux with Postgres and OIDC</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-bdd5cb4d6221fb90a00e10975627a6c8f7b37f97859d67fa7be393d0e754aa3e">+35/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add n8n stack with Postgres configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-38a154011609af380afb3b3672798982a33321906c20c47f3f5f944c2e5238be">+26/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add Nextflux stack exposure and defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-a06551061e4a6ebeed9456507029943bf3874affbb3c99c3dddc615f83f9d0ef">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add RSSHub stack with production settings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-09e8e594346b7d1a410eb2ba175a6c680a6ad33c7ed647f217e98282e246cd54">+10/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add Stirling-PDF stack with persisted volumes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-569de5b25a78d16c27cce6e40105797b35632fec39d35fea37eb385000b4bf4c">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>compose.yaml</strong><dd><code>Add YourSpotify stack with Mongo dependency</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/38/files#diff-ba124da50f2b2c75d828dbcc3994126b61948c1d44ed64aa5bd15c82c96b75de">+31/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

