### PR TITLE
feat: add Terraform CI/CD with GitHub Actions

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -37,6 +37,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Write sealed-secrets certs
+        run: |
+          mkdir -p modules/sealed-secrets/certs
+          echo "${{ secrets.SEALED_SECRETS_CERT }}" > modules/sealed-secrets/certs/sealed-secrets.cert
+          echo "${{ secrets.SEALED_SECRETS_KEY }}" > modules/sealed-secrets/certs/sealed-secrets.key
+
       - uses: hashicorp/setup-terraform@v3
         with:
           terraform_version: latest

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -19,15 +19,6 @@ jobs:
       TF_VAR_default_gateway: "${{ secrets.TF_VAR_DEFAULT_GATEWAY }}"
       TF_VAR_talos_cp_01_ip_addr: "${{ secrets.TF_VAR_TALOS_CP_01_IP }}"
       TF_VAR_talos_worker_01_ip_addr: "${{ secrets.TF_VAR_TALOS_WORKER_01_IP }}"
-      TF_VAR_externalservices_prometheus_host: "${{ secrets.TF_VAR_PROMETHEUS_HOST }}"
-      TF_VAR_externalservices_prometheus_basicauth_username: "${{ secrets.TF_VAR_PROMETHEUS_USERNAME }}"
-      TF_VAR_externalservices_prometheus_basicauth_password: "${{ secrets.TF_VAR_PROMETHEUS_PASSWORD }}"
-      TF_VAR_externalservices_loki_host: "${{ secrets.TF_VAR_LOKI_HOST }}"
-      TF_VAR_externalservices_loki_basicauth_username: "${{ secrets.TF_VAR_LOKI_USERNAME }}"
-      TF_VAR_externalservices_loki_basicauth_password: "${{ secrets.TF_VAR_LOKI_PASSWORD }}"
-      TF_VAR_externalservices_tempo_host: "${{ secrets.TF_VAR_TEMPO_HOST }}"
-      TF_VAR_externalservices_tempo_basicauth_username: "${{ secrets.TF_VAR_TEMPO_USERNAME }}"
-      TF_VAR_externalservices_tempo_basicauth_password: "${{ secrets.TF_VAR_TEMPO_PASSWORD }}"
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -5,11 +5,6 @@ on:
     paths:
       - 'terraform/**'
       - '.github/workflows/terraform.yaml'
-  push:
-    branches: [main]
-    paths:
-      - 'terraform/**'
-      - '.github/workflows/terraform.yaml'
 
 jobs:
   terraform:
@@ -57,17 +52,15 @@ jobs:
         run: terraform validate
 
       - name: Terraform Plan
-        if: github.event_name == 'pull_request'
         run: terraform plan -no-color -input=false
-        continue-on-error: true
         id: plan
 
       - name: Comment Plan on PR
-        if: github.event_name == 'pull_request'
+        if: always() && github.event_name == 'pull_request'
         uses: actions/github-script@v7
         with:
           script: |
-            const output = `#### Terraform Plan 📋
+            const output = `#### Terraform Plan ${{ steps.plan.outcome == 'success' && '✅' || '❌' }}
             \`\`\`
             ${{ steps.plan.outputs.stdout }}
             \`\`\`
@@ -79,7 +72,3 @@ jobs:
               repo: context.repo.repo,
               body: output
             });
-
-      - name: Terraform Apply
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: terraform apply -auto-approve -input=false

--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -1,0 +1,79 @@
+name: Terraform
+
+on:
+  pull_request:
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yaml'
+  push:
+    branches: [main]
+    paths:
+      - 'terraform/**'
+      - '.github/workflows/terraform.yaml'
+
+jobs:
+  terraform:
+    runs-on: [self-hosted, homelab]
+    defaults:
+      run:
+        working-directory: terraform
+
+    env:
+      TF_VAR_proxmox_endpoint: "https://192.168.1.100:8006"
+      TF_VAR_proxmox_api_token: "${{ secrets.PM_API_TOKEN_ID }}=${{ secrets.PM_API_TOKEN_SECRET }}"
+      TF_VAR_default_gateway: "${{ secrets.TF_VAR_DEFAULT_GATEWAY }}"
+      TF_VAR_talos_cp_01_ip_addr: "${{ secrets.TF_VAR_TALOS_CP_01_IP }}"
+      TF_VAR_talos_worker_01_ip_addr: "${{ secrets.TF_VAR_TALOS_WORKER_01_IP }}"
+      TF_VAR_externalservices_prometheus_host: "${{ secrets.TF_VAR_PROMETHEUS_HOST }}"
+      TF_VAR_externalservices_prometheus_basicauth_username: "${{ secrets.TF_VAR_PROMETHEUS_USERNAME }}"
+      TF_VAR_externalservices_prometheus_basicauth_password: "${{ secrets.TF_VAR_PROMETHEUS_PASSWORD }}"
+      TF_VAR_externalservices_loki_host: "${{ secrets.TF_VAR_LOKI_HOST }}"
+      TF_VAR_externalservices_loki_basicauth_username: "${{ secrets.TF_VAR_LOKI_USERNAME }}"
+      TF_VAR_externalservices_loki_basicauth_password: "${{ secrets.TF_VAR_LOKI_PASSWORD }}"
+      TF_VAR_externalservices_tempo_host: "${{ secrets.TF_VAR_TEMPO_HOST }}"
+      TF_VAR_externalservices_tempo_basicauth_username: "${{ secrets.TF_VAR_TEMPO_USERNAME }}"
+      TF_VAR_externalservices_tempo_basicauth_password: "${{ secrets.TF_VAR_TEMPO_PASSWORD }}"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: hashicorp/setup-terraform@v3
+        with:
+          terraform_version: latest
+
+      - name: Terraform Init
+        run: terraform init
+
+      - name: Terraform Format Check
+        run: terraform fmt -check -recursive
+
+      - name: Terraform Validate
+        run: terraform validate
+
+      - name: Terraform Plan
+        if: github.event_name == 'pull_request'
+        run: terraform plan -no-color -input=false
+        continue-on-error: true
+        id: plan
+
+      - name: Comment Plan on PR
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const output = `#### Terraform Plan 📋
+            \`\`\`
+            ${{ steps.plan.outputs.stdout }}
+            \`\`\`
+            *Triggered by @${{ github.actor }}*`;
+
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: output
+            });
+
+      - name: Terraform Apply
+        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
+        run: terraform apply -auto-approve -input=false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,8 +1,9 @@
 provider "proxmox" {
-  endpoint = var.proxmox_endpoint
-  username = var.proxmox_username
-  password = var.proxmox_password
-  insecure = true
+  endpoint  = var.proxmox_endpoint
+  api_token = var.proxmox_api_token != "" ? var.proxmox_api_token : null
+  username  = var.proxmox_api_token == "" ? var.proxmox_username : null
+  password  = var.proxmox_api_token == "" ? var.proxmox_password : null
+  insecure  = true
 
   ssh {
     agent = true

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -11,12 +11,22 @@ variable "proxmox_endpoint" {
 
 variable "proxmox_username" {
   type        = string
-  description = "Proxmox username"
+  description = "Proxmox username (used for local runs)"
+  default     = ""
 }
 
 variable "proxmox_password" {
   type        = string
-  description = "Proxmox password"
+  description = "Proxmox password (used for local runs)"
+  default     = ""
+  sensitive   = true
+}
+
+variable "proxmox_api_token" {
+  type        = string
+  description = "Proxmox API token in format user@realm!tokenid=secret (used for CI)"
+  default     = ""
+  sensitive   = true
 }
 
 variable "default_gateway" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -62,38 +62,46 @@ variable "monitoring_namespace" {
 }
 
 variable "externalservices_prometheus_host" {
-  type        = string
-  description = "Prometheus host"
+  type    = string
+  default = ""
 }
 
 variable "externalservices_prometheus_basicauth_username" {
-  type = number
+  type    = number
+  default = 0
 }
 
 variable "externalservices_prometheus_basicauth_password" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "externalservices_loki_host" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "externalservices_loki_basicauth_username" {
-  type = number
+  type    = number
+  default = 0
 }
 
 variable "externalservices_loki_basicauth_password" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "externalservices_tempo_host" {
-  type = string
+  type    = string
+  default = ""
 }
 
 variable "externalservices_tempo_basicauth_username" {
-  type = number
+  type    = number
+  default = 0
 }
 
 variable "externalservices_tempo_basicauth_password" {
-  type = string
+  type    = string
+  default = ""
 }


### PR DESCRIPTION
### **User description**
## Changes

- **Proxmox auth**: support both username/password (local) and API token (CI)
- **GitHub Actions workflow**: `terraform plan` on PR, `terraform apply` on merge to main
- **Self-hosted runner**: uses `komodo-runner` on homelab network

## Setup needed

Add these GitHub repo secrets:
- `PM_API_TOKEN_ID` — `terraform@pve!terraform`
- `PM_API_TOKEN_SECRET` — the token secret
- `TF_VAR_DEFAULT_GATEWAY`
- `TF_VAR_TALOS_CP_01_IP`
- `TF_VAR_TALOS_WORKER_01_IP`
- Monitoring vars (prometheus/loki/tempo host, username, password)

## After merge

Set up Terraform Cloud backend for remote state.


___

### **PR Type**
Enhancement


___

### **Description**
- Add GitHub Actions Terraform plan/apply pipeline

- Support Proxmox API token authentication in CI

- Default/sensitive provider credentials via variables


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pr["Pull request event"] 
  main["Push to main"]
  gha["GitHub Actions (self-hosted homelab runner)"]
  init["terraform init"]
  fmt["terraform fmt -check"]
  validate["terraform validate"]
  plan["terraform plan"]
  comment["Comment plan on PR"]
  apply["terraform apply"]
  proxmox["Proxmox provider auth (token or user/pass)"]

  pr -- "triggers" --> gha
  main -- "triggers" --> gha
  gha -- "runs" --> init
  init -- "then" --> fmt
  fmt -- "then" --> validate
  validate -- "PR only" --> plan
  plan -- "posts" --> comment
  validate -- "main only" --> apply
  gha -- "sets TF_VARs for" --> proxmox
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.tf</strong><dd><code>Conditional Proxmox authentication for CI and local</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/main.tf

<ul><li>Prefer <code>api_token</code> when provided<br> <li> Fall back to <code>username</code>/<code>password</code> otherwise<br> <li> Keep SSH agent and insecure settings</ul>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/39/files#diff-2e617c7870fa918457b1eee1c7d67ba82f19d043ae7b7918db26873e18793028">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>terraform.yaml</strong><dd><code>Add Terraform CI/CD workflow with PR feedback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/terraform.yaml

<ul><li>Add workflow triggers for PRs and main<br> <li> Run init/fmt/validate; plan on PRs<br> <li> Comment plan output back to PR<br> <li> Auto-apply on pushes to <code>main</code></ul>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/39/files#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3e">+79/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>variables.tf</strong><dd><code>Introduce Proxmox API token and safer defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

terraform/variables.tf

<ul><li>Add <code>proxmox_api_token</code> variable (sensitive)<br> <li> Default <code>proxmox_username</code>/<code>proxmox_password</code> to empty<br> <li> Mark <code>proxmox_password</code> as sensitive</ul>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/39/files#diff-b25e8cb262b29f5005a96d0c4a06a3deb77698fa6e11e4f43b21f6f4ad0f45e4">+12/-2</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

