### PR TITLE
security: block forked PRs from running on self-hosted runner

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   terraform:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: [self-hosted, homelab]
     defaults:
       run:


### PR DESCRIPTION
### **User description**
Adds `if: github.event.pull_request.head.repo.full_name == github.repository` to prevent forked PRs from executing on the self-hosted runner.

Also configure in Settings → Actions → Fork pull request workflows → Require approval for all outside collaborators.


___

### **PR Type**
Security, Configuration changes


___

### **Description**
- Block forked PRs from self-hosted runner


___

### Diagram Walkthrough


```mermaid
flowchart LR
  pr["Pull request event"]
  cond["Fork check: head repo == base repo"]
  job["terraform job (self-hosted runner)"]
  pr -- "triggers" --> cond
  cond -- "true: run" --> job
  cond -- "false: skip" --> job
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Security</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>terraform.yaml</strong><dd><code>Gate terraform job for non-fork PRs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/terraform.yaml

<ul><li>Add job-level <code>if</code> fork restriction<br> <li> Ensure self-hosted runner only for same-repo PRs</ul>


</details>


  </td>
  <td><a href="https://github.com/ravilushqa/homelab/pull/42/files#diff-5125e64cb591a598774a1b20f8fee8e4551204441592cbbbf523b9eb9c10cf3e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

