### PR TITLE
fix: use host IP for Komodo API in deploy workflow

### DIFF
--- a/.github/workflows/komodo-deploy.yaml
+++ b/.github/workflows/komodo-deploy.yaml
@@ -25,7 +25,7 @@ jobs:
       - name: Deploy to Komodo
         if: steps.changed.outputs.stacks != ''
         env:
-          KOMODO_API: http://localhost:9120
+          KOMODO_API: http://192.168.1.166:9120
           KOMODO_KEY: ${{ secrets.KOMODO_API_KEY }}
           KOMODO_SECRET: ${{ secrets.KOMODO_API_SECRET }}
         run: |


### PR DESCRIPTION
Runner is in a Docker network, cannot reach localhost:9120. Use host IP instead.