### PR TITLE
Refactor Terraform to support multiple Proxmox hosts

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,12 +29,13 @@ provider "kubernetes" {
 module "talos" {
   source = "./modules/talos"
 
-  talos_cp_01_ip_addr     = var.talos_cp_01_ip_addr
-  talos_worker_01_ip_addr = var.talos_worker_01_ip_addr
-  talos_cp_hostname       = "talos-cp-01"
-  talos_worker_hostname   = "talos-worker-01"
-  proxmox_node_name       = "pve01"
-  vm_ids                  = module.proxmox.vm_ids
+  talos_cp_01_ip_addr       = var.talos_cp_01_ip_addr
+  talos_worker_01_ip_addr   = var.talos_worker_01_ip_addr
+  talos_cp_01_node_name     = var.talos_cp_01_node_name
+  talos_worker_01_node_name = var.talos_worker_01_node_name
+  talos_cp_hostname         = "talos-cp-01"
+  talos_worker_hostname     = "talos-worker-01"
+  vm_ids                    = module.proxmox.vm_ids
 
   cilium = {
     values  = file("${path.module}/../k8s/infra/network/cilium/values.yaml")
@@ -43,13 +44,15 @@ module "talos" {
 }
 
 module "proxmox" {
-  source                  = "./modules/proxmox"
-  default_gateway         = var.default_gateway
-  talos_cp_01_ip_addr     = var.talos_cp_01_ip_addr
-  talos_worker_01_ip_addr = var.talos_worker_01_ip_addr
-  datastore_id            = var.datastore_id
-  talos_image_url         = module.talos.disk_image_url
-  talos_version           = module.talos.talos_version
+  source                    = "./modules/proxmox"
+  default_gateway           = var.default_gateway
+  talos_cp_01_ip_addr       = var.talos_cp_01_ip_addr
+  talos_worker_01_ip_addr   = var.talos_worker_01_ip_addr
+  talos_cp_01_node_name     = var.talos_cp_01_node_name
+  talos_worker_01_node_name = var.talos_worker_01_node_name
+  datastore_id              = var.datastore_id
+  talos_image_url           = module.talos.disk_image_url
+  talos_version             = module.talos.talos_version
 }
 
 module "monitoring" {

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -29,13 +29,8 @@ provider "kubernetes" {
 module "talos" {
   source = "./modules/talos"
 
-  talos_cp_01_ip_addr       = var.talos_cp_01_ip_addr
-  talos_worker_01_ip_addr   = var.talos_worker_01_ip_addr
-  talos_cp_01_node_name     = var.talos_cp_01_node_name
-  talos_worker_01_node_name = var.talos_worker_01_node_name
-  talos_cp_hostname         = "talos-cp-01"
-  talos_worker_hostname     = "talos-worker-01"
-  vm_ids                    = module.proxmox.vm_ids
+  nodes  = var.nodes
+  vm_ids = module.proxmox.vm_ids
 
   cilium = {
     values  = file("${path.module}/../k8s/infra/network/cilium/values.yaml")
@@ -44,15 +39,12 @@ module "talos" {
 }
 
 module "proxmox" {
-  source                    = "./modules/proxmox"
-  default_gateway           = var.default_gateway
-  talos_cp_01_ip_addr       = var.talos_cp_01_ip_addr
-  talos_worker_01_ip_addr   = var.talos_worker_01_ip_addr
-  talos_cp_01_node_name     = var.talos_cp_01_node_name
-  talos_worker_01_node_name = var.talos_worker_01_node_name
-  datastore_id              = var.datastore_id
-  talos_image_url           = module.talos.disk_image_url
-  talos_version             = module.talos.talos_version
+  source          = "./modules/proxmox"
+  default_gateway = var.default_gateway
+  nodes           = var.nodes
+  datastore_id    = var.datastore_id
+  talos_image_url = module.talos.disk_image_url
+  talos_version   = module.talos.talos_version
 }
 
 module "monitoring" {

--- a/terraform/modules/proxmox/files.tf
+++ b/terraform/modules/proxmox/files.tf
@@ -1,9 +1,11 @@
 # Download the Talos image using the URL provided by the Talos module
 # Note: Using replace() to change .raw.xz to .raw.gz since Proxmox provider only supports gz/lzo/zst/bz2
 resource "proxmox_virtual_environment_download_file" "talos_nocloud_image" {
+  for_each = toset(distinct([for k, v in local.vms : v.node_name]))
+
   content_type = "iso"
   datastore_id = "local"
-  node_name    = var.node_name
+  node_name    = each.key
 
   file_name               = "talos-${var.talos_version}-nocloud-amd64.img"
   url                     = replace(var.talos_image_url, ".raw.xz", ".raw.gz")

--- a/terraform/modules/proxmox/locals.tf
+++ b/terraform/modules/proxmox/locals.tf
@@ -27,29 +27,17 @@ locals {
 
   # VM-specific configurations
   vms = {
-    talos-cp-01 = {
-      ip_addr   = var.talos_cp_01_ip_addr
-      node_name = var.talos_cp_01_node_name
+    for k, v in var.nodes : k => {
+      ip_addr   = v.ip
+      node_name = v.host_node
+      type      = v.type
       cpu = {
-        cores = 2
+        cores = v.type == "controlplane" ? 2 : 4
         type  = "x86-64-v2-AES"
       }
       memory = {
         dedicated = 8192
       }
-    }
-
-    talos-worker-01 = {
-      ip_addr   = var.talos_worker_01_ip_addr
-      node_name = var.talos_worker_01_node_name
-      cpu = {
-        cores = 4
-        type  = "x86-64-v2-AES"
-      }
-      memory = {
-        dedicated = 8192
-      }
-      depends_on_cp = true
     }
   }
 }

--- a/terraform/modules/proxmox/locals.tf
+++ b/terraform/modules/proxmox/locals.tf
@@ -3,7 +3,6 @@ locals {
   common_vm_config = {
     description = "Managed by Terraform"
     tags        = ["terraform"]
-    node_name   = var.node_name
     on_boot     = true
 
     network_device = {
@@ -29,7 +28,8 @@ locals {
   # VM-specific configurations
   vms = {
     talos-cp-01 = {
-      ip_addr = var.talos_cp_01_ip_addr
+      ip_addr   = var.talos_cp_01_ip_addr
+      node_name = var.talos_cp_01_node_name
       cpu = {
         cores = 2
         type  = "x86-64-v2-AES"
@@ -40,7 +40,8 @@ locals {
     }
 
     talos-worker-01 = {
-      ip_addr = var.talos_worker_01_ip_addr
+      ip_addr   = var.talos_worker_01_ip_addr
+      node_name = var.talos_worker_01_node_name
       cpu = {
         cores = 4
         type  = "x86-64-v2-AES"

--- a/terraform/modules/proxmox/locals.tf
+++ b/terraform/modules/proxmox/locals.tf
@@ -32,11 +32,11 @@ locals {
       node_name = v.host_node
       type      = v.type
       cpu = {
-        cores = v.type == "controlplane" ? 2 : 4
+        cores = v.cpu
         type  = "x86-64-v2-AES"
       }
       memory = {
-        dedicated = 8192
+        dedicated = v.memory
       }
     }
   }

--- a/terraform/modules/proxmox/main.tf
+++ b/terraform/modules/proxmox/main.tf
@@ -5,7 +5,7 @@ resource "proxmox_virtual_environment_vm" "talos_cp" {
   name        = each.key
   description = local.common_vm_config.description
   tags        = local.common_vm_config.tags
-  node_name   = local.common_vm_config.node_name
+  node_name   = each.value.node_name
   on_boot     = local.common_vm_config.on_boot
 
   cpu {
@@ -60,7 +60,7 @@ resource "proxmox_virtual_environment_vm" "talos_workers" {
   name        = each.key
   description = local.common_vm_config.description
   tags        = local.common_vm_config.tags
-  node_name   = local.common_vm_config.node_name
+  node_name   = each.value.node_name
   on_boot     = local.common_vm_config.on_boot
 
   cpu {

--- a/terraform/modules/proxmox/main.tf
+++ b/terraform/modules/proxmox/main.tf
@@ -1,6 +1,6 @@
 # Control plane node
 resource "proxmox_virtual_environment_vm" "talos_cp" {
-  for_each = { for k, v in local.vms : k => v if !lookup(v, "depends_on_cp", false) }
+  for_each = { for k, v in local.vms : k => v if v.type == "controlplane" }
 
   name        = each.key
   description = local.common_vm_config.description
@@ -53,7 +53,7 @@ resource "proxmox_virtual_environment_vm" "talos_cp" {
 
 # Worker nodes (depend on control plane)
 resource "proxmox_virtual_environment_vm" "talos_workers" {
-  for_each = { for k, v in local.vms : k => v if lookup(v, "depends_on_cp", false) }
+  for_each = { for k, v in local.vms : k => v if v.type == "worker" }
 
   depends_on = [proxmox_virtual_environment_vm.talos_cp]
 

--- a/terraform/modules/proxmox/main.tf
+++ b/terraform/modules/proxmox/main.tf
@@ -27,7 +27,7 @@ resource "proxmox_virtual_environment_vm" "talos_cp" {
 
   disk {
     datastore_id = local.common_vm_config.disk.datastore_id
-    file_id      = proxmox_virtual_environment_download_file.talos_nocloud_image.id
+    file_id      = proxmox_virtual_environment_download_file.talos_nocloud_image[each.value.node_name].id
     file_format  = local.common_vm_config.disk.file_format
     interface    = local.common_vm_config.disk.interface
     size         = local.common_vm_config.disk.size
@@ -82,7 +82,7 @@ resource "proxmox_virtual_environment_vm" "talos_workers" {
 
   disk {
     datastore_id = local.common_vm_config.disk.datastore_id
-    file_id      = proxmox_virtual_environment_download_file.talos_nocloud_image.id
+    file_id      = proxmox_virtual_environment_download_file.talos_nocloud_image[each.value.node_name].id
     file_format  = local.common_vm_config.disk.file_format
     interface    = local.common_vm_config.disk.interface
     size         = local.common_vm_config.disk.size

--- a/terraform/modules/proxmox/main.tf
+++ b/terraform/modules/proxmox/main.tf
@@ -105,3 +105,8 @@ resource "proxmox_virtual_environment_vm" "talos_workers" {
     }
   }
 }
+
+moved {
+  from = proxmox_virtual_environment_download_file.talos_nocloud_image
+  to   = proxmox_virtual_environment_download_file.talos_nocloud_image["pve01"]
+}

--- a/terraform/modules/proxmox/outputs.tf
+++ b/terraform/modules/proxmox/outputs.tf
@@ -1,13 +1,3 @@
-output "talos_cp_01_vm_id" {
-  value       = proxmox_virtual_environment_vm.talos_cp["talos-cp-01"].id
-  description = "ID of the Talos control plane VM in Proxmox"
-}
-
-output "talos_worker_01_vm_id" {
-  value       = proxmox_virtual_environment_vm.talos_workers["talos-worker-01"].id
-  description = "ID of the Talos worker VM in Proxmox"
-}
-
 output "vm_ids" {
   value = merge(
     { for name, vm in proxmox_virtual_environment_vm.talos_cp : name => vm.id },
@@ -19,12 +9,4 @@ output "vm_ids" {
 output "node_names" {
   value       = { for k, v in local.vms : k => v.node_name }
   description = "Map of VM names to their Proxmox node names"
-}
-
-output "vm_hostnames" {
-  value = {
-    control_plane = keys({ for k, v in local.vms : k => v if !lookup(v, "depends_on_cp", false) })[0]
-    worker        = keys({ for k, v in local.vms : k => v if lookup(v, "depends_on_cp", false) })[0]
-  }
-  description = "Hostnames for control plane and worker VMs"
 }

--- a/terraform/modules/proxmox/outputs.tf
+++ b/terraform/modules/proxmox/outputs.tf
@@ -16,9 +16,9 @@ output "vm_ids" {
   description = "Map of all VM names to their IDs"
 }
 
-output "node_name" {
-  value       = var.node_name
-  description = "Proxmox node name where VMs are created"
+output "node_names" {
+  value       = { for k, v in local.vms : k => v.node_name }
+  description = "Map of VM names to their Proxmox node names"
 }
 
 output "vm_hostnames" {

--- a/terraform/modules/proxmox/variables.tf
+++ b/terraform/modules/proxmox/variables.tf
@@ -8,15 +8,21 @@ variable "talos_worker_01_ip_addr" {
   description = "IP address for the Talos worker node"
 }
 
+variable "talos_cp_01_node_name" {
+  type        = string
+  default     = "pve01"
+  description = "Proxmox node name for control plane"
+}
+
+variable "talos_worker_01_node_name" {
+  type        = string
+  default     = "pve01"
+  description = "Proxmox node name for worker node"
+}
+
 variable "default_gateway" {
   type        = string
   description = "Default gateway for network configuration"
-}
-
-variable "node_name" {
-  type        = string
-  default     = "pve01"
-  description = "Name of the Proxmox node where VMs are created"
 }
 
 variable "datastore_id" {

--- a/terraform/modules/proxmox/variables.tf
+++ b/terraform/modules/proxmox/variables.tf
@@ -1,23 +1,10 @@
-variable "talos_cp_01_ip_addr" {
-  type        = string
-  description = "IP address for the Talos control plane node"
-}
-
-variable "talos_worker_01_ip_addr" {
-  type        = string
-  description = "IP address for the Talos worker node"
-}
-
-variable "talos_cp_01_node_name" {
-  type        = string
-  default     = "pve01"
-  description = "Proxmox node name for control plane"
-}
-
-variable "talos_worker_01_node_name" {
-  type        = string
-  default     = "pve01"
-  description = "Proxmox node name for worker node"
+variable "nodes" {
+  description = "Configuration for cluster nodes"
+  type = map(object({
+    host_node = string
+    ip        = string
+    type      = string
+  }))
 }
 
 variable "default_gateway" {

--- a/terraform/modules/proxmox/variables.tf
+++ b/terraform/modules/proxmox/variables.tf
@@ -4,6 +4,8 @@ variable "nodes" {
     host_node = string
     ip        = string
     type      = string
+    cpu       = number
+    memory    = number
   }))
 }
 

--- a/terraform/modules/talos/main.tf
+++ b/terraform/modules/talos/main.tf
@@ -1,30 +1,37 @@
 resource "talos_machine_secrets" "machine_secrets" {}
 
+locals {
+  cp_nodes     = { for k, v in var.nodes : k => v if v.type == "controlplane" }
+  worker_nodes = { for k, v in var.nodes : k => v if v.type == "worker" }
+  first_cp_ip  = values(local.cp_nodes)[0].ip
+}
+
 data "talos_client_configuration" "talosconfig" {
   cluster_name         = var.cluster_name
   client_configuration = talos_machine_secrets.machine_secrets.client_configuration
-  endpoints            = [var.talos_cp_01_ip_addr]
+  endpoints            = [for k, v in local.cp_nodes : v.ip]
 }
 
 data "talos_machine_configuration" "machineconfig_cp" {
   cluster_name     = var.cluster_name
-  cluster_endpoint = "https://${var.talos_cp_01_ip_addr}:6443"
+  cluster_endpoint = "https://${local.first_cp_ip}:6443"
   machine_type     = "controlplane"
   machine_secrets  = talos_machine_secrets.machine_secrets.machine_secrets
 }
 
 resource "talos_machine_configuration_apply" "cp_config_apply" {
+  for_each = local.cp_nodes
+
   # Ensure VMs are created before applying configuration
   depends_on = [var.vm_ids]
 
   client_configuration        = talos_machine_secrets.machine_secrets.client_configuration
   machine_configuration_input = data.talos_machine_configuration.machineconfig_cp.machine_configuration
-  count                       = 1
-  node                        = var.talos_cp_01_ip_addr
+  node                        = each.value.ip
   config_patches = [
     templatefile("${path.module}/patches/control-plane.yaml.tmpl", {
-      hostname       = var.talos_cp_hostname
-      node_name      = var.talos_cp_01_node_name
+      hostname       = each.key
+      node_name      = each.value.host_node
       cluster_name   = var.cluster_name
       cilium_values  = var.cilium.values
       cilium_install = var.cilium.install
@@ -34,23 +41,24 @@ resource "talos_machine_configuration_apply" "cp_config_apply" {
 
 data "talos_machine_configuration" "machineconfig_worker" {
   cluster_name     = var.cluster_name
-  cluster_endpoint = "https://${var.talos_cp_01_ip_addr}:6443"
+  cluster_endpoint = "https://${local.first_cp_ip}:6443"
   machine_type     = "worker"
   machine_secrets  = talos_machine_secrets.machine_secrets.machine_secrets
 }
 
 resource "talos_machine_configuration_apply" "worker_config_apply" {
+  for_each = local.worker_nodes
+
   # Ensure VMs are created before applying configuration
   depends_on = [var.vm_ids]
 
   client_configuration        = talos_machine_secrets.machine_secrets.client_configuration
   machine_configuration_input = data.talos_machine_configuration.machineconfig_worker.machine_configuration
-  count                       = 1
-  node                        = var.talos_worker_01_ip_addr
+  node                        = each.value.ip
   config_patches = [
     templatefile("${path.module}/patches/worker.yaml.tmpl", {
-      hostname     = var.talos_worker_hostname
-      node_name    = var.talos_worker_01_node_name
+      hostname     = each.key
+      node_name    = each.value.host_node
       cluster_name = var.cluster_name
     }),
   ]
@@ -59,14 +67,14 @@ resource "talos_machine_configuration_apply" "worker_config_apply" {
 resource "talos_machine_bootstrap" "bootstrap" {
   depends_on           = [talos_machine_configuration_apply.cp_config_apply]
   client_configuration = talos_machine_secrets.machine_secrets.client_configuration
-  node                 = var.talos_cp_01_ip_addr
+  node                 = local.first_cp_ip
 }
 
 data "talos_cluster_health" "health" {
   depends_on           = [talos_machine_configuration_apply.cp_config_apply, talos_machine_configuration_apply.worker_config_apply]
   client_configuration = data.talos_client_configuration.talosconfig.client_configuration
-  control_plane_nodes  = [var.talos_cp_01_ip_addr]
-  worker_nodes         = [var.talos_worker_01_ip_addr]
+  control_plane_nodes  = [for k, v in local.cp_nodes : v.ip]
+  worker_nodes         = [for k, v in local.worker_nodes : v.ip]
   endpoints            = data.talos_client_configuration.talosconfig.endpoints
   timeouts = {
     read = "10m"
@@ -76,7 +84,7 @@ data "talos_cluster_health" "health" {
 resource "talos_cluster_kubeconfig" "kubeconfig" {
   depends_on           = [talos_machine_bootstrap.bootstrap, data.talos_cluster_health.health]
   client_configuration = talos_machine_secrets.machine_secrets.client_configuration
-  node                 = var.talos_cp_01_ip_addr
+  node                 = local.first_cp_ip
   timeouts = {
     read = "1m"
   }

--- a/terraform/modules/talos/main.tf
+++ b/terraform/modules/talos/main.tf
@@ -24,7 +24,7 @@ resource "talos_machine_configuration_apply" "cp_config_apply" {
   config_patches = [
     templatefile("${path.module}/patches/control-plane.yaml.tmpl", {
       hostname       = var.talos_cp_hostname
-      node_name      = var.proxmox_node_name
+      node_name      = var.talos_cp_01_node_name
       cluster_name   = var.cluster_name
       cilium_values  = var.cilium.values
       cilium_install = var.cilium.install
@@ -50,7 +50,7 @@ resource "talos_machine_configuration_apply" "worker_config_apply" {
   config_patches = [
     templatefile("${path.module}/patches/worker.yaml.tmpl", {
       hostname     = var.talos_worker_hostname
-      node_name    = var.proxmox_node_name
+      node_name    = var.talos_worker_01_node_name
       cluster_name = var.cluster_name
     }),
   ]

--- a/terraform/modules/talos/main.tf
+++ b/terraform/modules/talos/main.tf
@@ -89,3 +89,13 @@ resource "talos_cluster_kubeconfig" "kubeconfig" {
     read = "1m"
   }
 }
+
+moved {
+  from = talos_machine_configuration_apply.cp_config_apply[0]
+  to   = talos_machine_configuration_apply.cp_config_apply["talos-cp-01"]
+}
+
+moved {
+  from = talos_machine_configuration_apply.worker_config_apply[0]
+  to   = talos_machine_configuration_apply.worker_config_apply["talos-worker-01"]
+}

--- a/terraform/modules/talos/variables.tf
+++ b/terraform/modules/talos/variables.tf
@@ -26,9 +26,15 @@ variable "talos_worker_hostname" {
   default     = "talos-worker-01"
 }
 
-variable "proxmox_node_name" {
+variable "talos_cp_01_node_name" {
   type        = string
-  description = "Name of the Proxmox node where VMs are created"
+  description = "Proxmox node name for control plane"
+  default     = "pve01"
+}
+
+variable "talos_worker_01_node_name" {
+  type        = string
+  description = "Proxmox node name for worker node"
   default     = "pve01"
 }
 

--- a/terraform/modules/talos/variables.tf
+++ b/terraform/modules/talos/variables.tf
@@ -4,38 +4,13 @@ variable "cluster_name" {
   default     = "cluster01"
 }
 
-variable "talos_cp_01_ip_addr" {
-  type        = string
-  description = "IP address for the Talos control plane node"
-}
-
-variable "talos_worker_01_ip_addr" {
-  type        = string
-  description = "IP address for the Talos worker node"
-}
-
-variable "talos_cp_hostname" {
-  type        = string
-  description = "Hostname for the Talos control plane node"
-  default     = "talos-cp-01"
-}
-
-variable "talos_worker_hostname" {
-  type        = string
-  description = "Hostname for the Talos worker node"
-  default     = "talos-worker-01"
-}
-
-variable "talos_cp_01_node_name" {
-  type        = string
-  description = "Proxmox node name for control plane"
-  default     = "pve01"
-}
-
-variable "talos_worker_01_node_name" {
-  type        = string
-  description = "Proxmox node name for worker node"
-  default     = "pve01"
+variable "nodes" {
+  description = "Configuration for cluster nodes"
+  type = map(object({
+    host_node = string
+    ip        = string
+    type      = string
+  }))
 }
 
 variable "cilium" {

--- a/terraform/modules/talos/variables.tf
+++ b/terraform/modules/talos/variables.tf
@@ -10,6 +10,8 @@ variable "nodes" {
     host_node = string
     ip        = string
     type      = string
+    cpu       = number
+    memory    = number
   }))
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -44,6 +44,18 @@ variable "talos_worker_01_ip_addr" {
   description = "IP address for worker node"
 }
 
+variable "talos_cp_01_node_name" {
+  type        = string
+  description = "Proxmox node name for control plane"
+  default     = "pve01"
+}
+
+variable "talos_worker_01_node_name" {
+  type        = string
+  description = "Proxmox node name for worker node"
+  default     = "pve01"
+}
+
 variable "datastore_id" {
   type        = string
   default     = "local-lvm"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -34,26 +34,25 @@ variable "default_gateway" {
   description = "IP address of your default gateway"
 }
 
-variable "talos_cp_01_ip_addr" {
-  type        = string
-  description = "IP address for control plane"
-}
-
-variable "talos_worker_01_ip_addr" {
-  type        = string
-  description = "IP address for worker node"
-}
-
-variable "talos_cp_01_node_name" {
-  type        = string
-  description = "Proxmox node name for control plane"
-  default     = "pve01"
-}
-
-variable "talos_worker_01_node_name" {
-  type        = string
-  description = "Proxmox node name for worker node"
-  default     = "pve01"
+variable "nodes" {
+  description = "Configuration for cluster nodes"
+  type = map(object({
+    host_node = string
+    ip        = string
+    type      = string
+  }))
+  default = {
+    "talos-cp-01" = {
+      host_node = "pve01"
+      ip        = "10.0.10.10"
+      type      = "controlplane"
+    }
+    "talos-worker-01" = {
+      host_node = "pve01"
+      ip        = "10.0.10.11"
+      type      = "worker"
+    }
+  }
 }
 
 variable "datastore_id" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -31,6 +31,7 @@ variable "proxmox_api_token" {
 
 variable "default_gateway" {
   type        = string
+  default     = "192.168.1.1"
   description = "IP address of your default gateway"
 }
 
@@ -40,17 +41,23 @@ variable "nodes" {
     host_node = string
     ip        = string
     type      = string
+    cpu       = number
+    memory    = number
   }))
   default = {
     "talos-cp-01" = {
       host_node = "pve01"
-      ip        = "10.0.10.10"
+      ip        = "192.168.1.210"
       type      = "controlplane"
+      cpu       = 2
+      memory    = 8192
     }
     "talos-worker-01" = {
       host_node = "pve01"
-      ip        = "10.0.10.11"
+      ip        = "192.168.1.211"
       type      = "worker"
+      cpu       = 4
+      memory    = 8192
     }
   }
 }


### PR DESCRIPTION
This PR refactors the Terraform configuration to support deploying Talos Control Plane and Worker nodes on different Proxmox hosts. It introduces new variables for specifying the node name for each VM and updates the modules to respect these configurations. It also cleans up unused variables.

---
*PR created automatically by Jules for task [16225007756088613442](https://jules.google.com/task/16225007756088613442) started by @ravilushqa*