### PR TITLE
fix(github-runner): make runner ephemeral

### DIFF
--- a/stacks/github-runner/compose.yaml
+++ b/stacks/github-runner/compose.yaml
@@ -8,9 +8,7 @@ services:
       ACCESS_TOKEN: "${ACCESS_TOKEN}"
       RUNNER_WORKDIR: /tmp/runner/work
       LABELS: self-hosted,linux,x64,homelab
+      EPHEMERAL: "true"
+      DISABLE_AUTO_UPDATE: "true"
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock
-      - runner-work:/tmp/runner/work
-
-volumes:
-  runner-work:


### PR DESCRIPTION
Runner breaks after container restarts because stale registration state. Adding `EPHEMERAL=true` makes it re-register on every start.

Also added `DISABLE_AUTO_UPDATE=true` to prevent mid-run update issues.