### PR TITLE
fix(traefik): invert TCP routing — Komodo as catch-all, K8s explicit

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -35,6 +35,20 @@
   ```
 - **Networking**: Use Gateway API (HTTP/TLS routes) for ingress traffic
 
+## Traefik TCP Routing (terraform/modules/traefik/configs/tcp_routers.yaml)
+Traffic enters via a Traefik instance that does TLS passthrough to two backends:
+- **Komodo host** (`192.168.1.166:443`) — Docker Compose stacks managed by Komodo
+- **K8s cluster** (`192.168.1.222:443`) — Kubernetes-served services
+
+**Routing logic**: `komodo-tcp-router` is the catch-all (`HostSNI("*")`, priority 50).
+`k8s-tcp-router` has an explicit list of K8s domains (priority 100).
+
+- **Adding a new Komodo service**: no change needed in `tcp_routers.yaml`
+- **Adding a new K8s service**: add its hostname to `k8s-tcp-router` rule
+
+K8s domains (as of last update): `argocd`, `glance`, `dozzle`, `it-tools`, `inbox-zero`,
+`changedetection`, `grafana`, `ha`, `openwebui`, `pocketid`, `proxmox` (all `.ravil.space`)
+
 ## Best Practices
 - Document major components in README.md
 - Keep infrastructure as code (Terraform, Kubernetes manifests)

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -10,7 +10,6 @@ Secrets are stored in Komodo Variables/Secrets — never in this repo.
 ## Required Secrets in Komodo
 
 ### traefik
-- `DOMAIN`
 - `ACME_EMAIL`
 - `CF_DNS_API_TOKEN`
 - `TRAEFIK_OIDC_CLIENT_ID`

--- a/terraform/modules/traefik/configs/tcp_routers.yaml
+++ b/terraform/modules/traefik/configs/tcp_routers.yaml
@@ -1,33 +1,34 @@
 tcp:
   routers:
-    komodo-tcp-router:
+    # K8s services are listed explicitly here (priority 100).
+    # Everything else falls through to komodo-tcp-router (catch-all).
+    # When adding a new K8s-served domain, add it here.
+    # When adding a new Komodo-served domain, no change needed here.
+    k8s-tcp-router:
       entryPoints:
         - websecure
       rule: >-
-        HostSNIRegexp(`^.+\.test\.ravil\.space$`)
-        || HostSNI(`paperless.ravil.space`)
-        || HostSNI(`bytestash.ravil.space`)
+        HostSNI(`argocd.ravil.space`)
+        || HostSNI(`glance.ravil.space`)
         || HostSNI(`dozzle.ravil.space`)
-        || HostSNI(`nextflux.ravil.space`)
-        || HostSNI(`rsshub.ravil.space`)
-        || HostSNI(`pdf.ravil.space`)
-        || HostSNI(`n8n.ravil.space`)
-        || HostSNI(`miniflux.ravil.space`)
-        || HostSNI(`karakeep.ravil.space`)
-        || HostSNI(`spotify.ravil.space`)
-        || HostSNI(`spotify-server.ravil.space`)
-        || HostSNI(`immich.ravil.space`)
-        || HostSNI(`komodo.ravil.space`)
-      service: komodo-tcp-service
+        || HostSNI(`it-tools.ravil.space`)
+        || HostSNI(`inbox-zero.ravil.space`)
+        || HostSNI(`changedetection.ravil.space`)
+        || HostSNI(`grafana.ravil.space`)
+        || HostSNI(`ha.ravil.space`)
+        || HostSNI(`openwebui.ravil.space`)
+        || HostSNI(`pocketid.ravil.space`)
+        || HostSNI(`proxmox.ravil.space`)
+      service: k8s-tcp-service
       priority: 100
       tls:
         passthrough: true
 
-    k8s-tcp-router:
+    komodo-tcp-router:
       entryPoints:
         - websecure
       rule: 'HostSNI("*")'
-      service: k8s-tcp-service
+      service: komodo-tcp-service
       priority: 50
       tls:
         passthrough: true


### PR DESCRIPTION
## Summary

- **Invert TCP router logic**: `komodo-tcp-router` is now the catch-all (`HostSNI("*")`, priority 50); `k8s-tcp-router` lists K8s-served domains explicitly (priority 100). New Komodo services no longer require changes to `tcp_routers.yaml`.
- **Fix `dozzle.ravil.space`**: was incorrectly routed to Komodo host; moved to the K8s list where it belongs.
- **Add `traefik.ravil.space` and `whoami.ravil.space`**: were missing, causing traffic to fall through to K8s instead of Komodo.
- **Remove `HostSNIRegexp` for `test.ravil.space`**: no longer needed.
- **Remove `DOMAIN` from Komodo secrets**: domain is now hardcoded in compose labels.
- **Document routing pattern** in `CLAUDE.md` for future reference.

## Test plan

- [ ] Apply Terraform changes
- [ ] Verify `whoami.ravil.space` is accessible
- [ ] Verify `traefik.ravil.space` is accessible (requires OIDC via PocketID)
- [ ] Verify K8s services (e.g. `argocd.ravil.space`, `pocketid.ravil.space`) still work
- [ ] Verify Komodo services (e.g. `paperless.ravil.space`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)