### PR TITLE
feat(traefik): add http.cat error pages as global middleware

### DIFF
--- a/stacks/traefik/compose.yaml
+++ b/stacks/traefik/compose.yaml
@@ -17,6 +17,9 @@ services:
       - --entrypoints.web.http.redirections.entrypoint.scheme=https
       - --entrypoints.web.http.redirections.entrypoint.permanent=true
 
+      # Default middlewares for all routers
+      - --entrypoints.websecure.http.middlewares=http-cat@docker
+
       # Docker provider
       - --providers.docker=true
       - --providers.docker.exposedbydefault=false
@@ -67,6 +70,11 @@ services:
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Provider.ClientSecret=${TRAEFIK_OIDC_CLIENT_SECRET}"
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Scopes=openid,profile,email"
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Secret=${OIDC_SECRET}"
+      # http.cat error pages middleware
+      - "traefik.http.middlewares.http-cat.errors.status=400-599"
+      - "traefik.http.middlewares.http-cat.errors.service=http-cat-svc@docker"
+      - "traefik.http.middlewares.http-cat.errors.query=/{status}"
+      - "traefik.http.services.http-cat-svc.loadbalancer.server.url=https://http.cat"
 
   whoami:
     image: traefik/whoami


### PR DESCRIPTION
## Summary
- Defines an `http-cat` errors middleware in the Komodo Traefik stack that intercepts 4xx/5xx responses and proxies them to `https://http.cat/{status}`
- Attaches the middleware globally to the `websecure` entrypoint so all routers benefit automatically without per-service configuration

## Test plan
- [ ] Deploy updated Traefik stack on Komodo
- [ ] Trigger a 404 (e.g. visit a non-existent path on any service) and confirm a cat image is returned
- [ ] Confirm existing OIDC auth flows are unaffected (redirects are 302, not caught by the middleware)

🤖 Generated with [Claude Code](https://claude.com/claude-code)