### PR TITLE
feat: add Umami analytics with traefik-umami-feeder plugin

### DIFF
--- a/stacks/traefik/compose.yaml
+++ b/stacks/traefik/compose.yaml
@@ -40,6 +40,10 @@ services:
       - --experimental.plugins.traefik-oidc-auth.modulename=github.com/sevensolutions/traefik-oidc-auth
       - --experimental.plugins.traefik-oidc-auth.version=v0.15.0
 
+      # Umami analytics plugin
+      - --experimental.plugins.umami-feeder.modulename=github.com/astappiev/traefik-umami-feeder
+      - --experimental.plugins.umami-feeder.version=v1.4.0
+
     ports:
       - "80:80"
       - "443:443"
@@ -67,6 +71,11 @@ services:
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Provider.ClientSecret=${TRAEFIK_OIDC_CLIENT_SECRET}"
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Scopes=openid,profile,email"
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Secret=${OIDC_SECRET}"
+      # Umami analytics middleware
+      - "traefik.http.middlewares.umami.plugin.umami-feeder.umamiHost=http://umami:3000"
+      - "traefik.http.middlewares.umami.plugin.umami-feeder.umamiUsername=${UMAMI_USERNAME}"
+      - "traefik.http.middlewares.umami.plugin.umami-feeder.umamiPassword=${UMAMI_PASSWORD}"
+      - "traefik.http.middlewares.umami.plugin.umami-feeder.createNewWebsites=true"
 
   whoami:
     image: traefik/whoami

--- a/stacks/umami/compose.yaml
+++ b/stacks/umami/compose.yaml
@@ -1,0 +1,47 @@
+services:
+  umami:
+    image: ghcr.io/umami-software/umami:postgresql-latest
+    container_name: umami
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://umami:${UMAMI_DB_PASSWORD}@umami-db:5432/umami
+      APP_SECRET: ${UMAMI_APP_SECRET}
+    depends_on:
+      umami-db:
+        condition: service_healthy
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.umami.rule=Host(`umami.ravil.space`)"
+      - "traefik.http.routers.umami.entrypoints=websecure"
+      - "traefik.http.routers.umami.tls.certresolver=cloudflare"
+      - "traefik.http.services.umami.loadbalancer.server.port=3000"
+      - "traefik.docker.network=traefik_default"
+
+  umami-db:
+    image: postgres:17-alpine
+    container_name: umami-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: umami
+      POSTGRES_USER: umami
+      POSTGRES_PASSWORD: ${UMAMI_DB_PASSWORD}
+    volumes:
+      - umami-db:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U umami"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  umami-db:
+
+networks:
+  default:
+    name: umami_default
+  traefik:
+    name: traefik_default
+    external: true


### PR DESCRIPTION
## What
- Add **Umami** self-hosted analytics stack (Umami + PostgreSQL)
- Register **traefik-umami-feeder** plugin in Traefik
- Configure server-side analytics middleware

## How it works
- `umami-feeder` plugin sends request data to Umami API from Traefik middleware (no JS/cookies)
- Auto-discovers and creates websites in Umami via API credentials
- Umami accessible at `umami.ravil.space`

## After merge
1. Add DNS record `umami.ravil.space` in Cloudflare
2. Add Komodo env vars:
   - `UMAMI_DB_PASSWORD` (for umami stack)
   - `UMAMI_APP_SECRET` (for umami stack)
   - `UMAMI_USERNAME` / `UMAMI_PASSWORD` (for traefik stack — Umami admin creds)
3. Deploy umami stack first, then redeploy traefik
4. Add `umami@docker` middleware to routers you want to track