### PR TITLE
feat: add umami analytics middleware to all services

### DIFF
--- a/stacks/bytestash/compose.yaml
+++ b/stacks/bytestash/compose.yaml
@@ -24,6 +24,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.bytestash.rule=Host(`bytestash.ravil.space`)"
+      - "traefik.http.routers.bytestash.middlewares=umami@docker"
       - "traefik.http.routers.bytestash.entrypoints=websecure"
       - "traefik.http.routers.bytestash.tls.certresolver=cloudflare"
       - "traefik.http.services.bytestash.loadbalancer.server.port=5000"

--- a/stacks/dozzle/compose.yaml
+++ b/stacks/dozzle/compose.yaml
@@ -17,7 +17,7 @@ services:
       - "traefik.http.routers.dozzle.tls.certresolver=cloudflare"
       - "traefik.http.services.dozzle.loadbalancer.server.port=8080"
       - "traefik.docker.network=traefik_default"
-      - "traefik.http.routers.dozzle.middlewares=oidc-auth@docker"
+      - "traefik.http.routers.dozzle.middlewares=oidc-auth@docker,umami@docker"
 
 networks:
   default:

--- a/stacks/immich/compose.yaml
+++ b/stacks/immich/compose.yaml
@@ -27,6 +27,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.immich.rule=Host(`immich.ravil.space`)"
+      - "traefik.http.routers.immich.middlewares=umami@docker"
       - "traefik.http.routers.immich.entrypoints=websecure"
       - "traefik.http.routers.immich.tls.certresolver=cloudflare"
       - "traefik.http.services.immich.loadbalancer.server.port=2283"

--- a/stacks/karakeep/compose.yaml
+++ b/stacks/karakeep/compose.yaml
@@ -27,6 +27,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.karakeep.rule=Host(`karakeep.ravil.space`)"
+      - "traefik.http.routers.karakeep.middlewares=umami@docker"
       - "traefik.http.routers.karakeep.entrypoints=websecure"
       - "traefik.http.routers.karakeep.tls.certresolver=cloudflare"
       - "traefik.http.services.karakeep.loadbalancer.server.port=3000"

--- a/stacks/miniflux/compose.yaml
+++ b/stacks/miniflux/compose.yaml
@@ -34,6 +34,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.miniflux.rule=Host(`miniflux.ravil.space`)"
+      - "traefik.http.routers.miniflux.middlewares=umami@docker"
       - "traefik.http.routers.miniflux.entrypoints=websecure"
       - "traefik.http.routers.miniflux.tls.certresolver=cloudflare"
       - "traefik.http.services.miniflux.loadbalancer.server.port=8080"

--- a/stacks/n8n/compose.yaml
+++ b/stacks/n8n/compose.yaml
@@ -26,6 +26,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.n8n.rule=Host(`n8n.ravil.space`)"
+      - "traefik.http.routers.n8n.middlewares=umami@docker"
       - "traefik.http.routers.n8n.entrypoints=websecure"
       - "traefik.http.routers.n8n.tls.certresolver=cloudflare"
       - "traefik.http.services.n8n.loadbalancer.server.port=5678"

--- a/stacks/nextflux/compose.yaml
+++ b/stacks/nextflux/compose.yaml
@@ -13,7 +13,7 @@ services:
       - "traefik.http.routers.nextflux.tls.certresolver=cloudflare"
       - "traefik.http.services.nextflux.loadbalancer.server.port=3000"
       - "traefik.docker.network=traefik_default"
-      - "traefik.http.routers.nextflux.middlewares=oidc-auth@docker"
+      - "traefik.http.routers.nextflux.middlewares=oidc-auth@docker,umami@docker"
 
 networks:
   default:

--- a/stacks/paperless-ngx/compose.yaml
+++ b/stacks/paperless-ngx/compose.yaml
@@ -30,6 +30,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.paperless.rule=Host(`paperless.ravil.space`)"
+      - "traefik.http.routers.paperless.middlewares=umami@docker"
       - "traefik.http.routers.paperless.entrypoints=websecure"
       - "traefik.http.routers.paperless.tls.certresolver=cloudflare"
       - "traefik.http.services.paperless.loadbalancer.server.port=8000"

--- a/stacks/rsshub/compose.yaml
+++ b/stacks/rsshub/compose.yaml
@@ -18,7 +18,7 @@ services:
       - "traefik.http.routers.rsshub.tls.certresolver=cloudflare"
       - "traefik.http.services.rsshub.loadbalancer.server.port=1200"
       - "traefik.docker.network=traefik_default"
-      - "traefik.http.routers.rsshub.middlewares=oidc-auth@docker"
+      - "traefik.http.routers.rsshub.middlewares=oidc-auth@docker,umami@docker"
 
 networks:
   default:

--- a/stacks/s-pdf/compose.yaml
+++ b/stacks/s-pdf/compose.yaml
@@ -21,7 +21,7 @@ services:
       - "traefik.http.routers.s-pdf.tls.certresolver=cloudflare"
       - "traefik.http.services.s-pdf.loadbalancer.server.port=8080"
       - "traefik.docker.network=traefik_default"
-      - "traefik.http.routers.s-pdf.middlewares=oidc-auth@docker"
+      - "traefik.http.routers.s-pdf.middlewares=oidc-auth@docker,umami@docker"
 
 volumes:
   trainingData:

--- a/stacks/traefik/compose.yaml
+++ b/stacks/traefik/compose.yaml
@@ -64,7 +64,7 @@ services:
       - "traefik.http.routers.traefik-dashboard.tls.certresolver=cloudflare"
       - "traefik.http.routers.traefik-dashboard.service=api@internal"
       - "traefik.http.routers.traefik-dashboard.priority=100"
-      - "traefik.http.routers.traefik-dashboard.middlewares=oidc-auth@docker"
+      - "traefik.http.routers.traefik-dashboard.middlewares=oidc-auth@docker,umami@docker"
       # Global OIDC middleware
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Provider.Url=https://pocketid.ravil.space"
       - "traefik.http.middlewares.oidc-auth.plugin.traefik-oidc-auth.Provider.ClientId=${TRAEFIK_OIDC_CLIENT_ID}"

--- a/stacks/your_spotify/compose.yaml
+++ b/stacks/your_spotify/compose.yaml
@@ -15,6 +15,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.spotify-server.rule=Host(`spotify-server.ravil.space`)"
+      - "traefik.http.routers.spotify-server.middlewares=umami@docker"
       - "traefik.http.routers.spotify-server.entrypoints=websecure"
       - "traefik.http.routers.spotify-server.tls.certresolver=cloudflare"
       - "traefik.http.services.spotify-server.loadbalancer.server.port=8080"
@@ -38,6 +39,7 @@ services:
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.spotify-web.rule=Host(`spotify.ravil.space`)"
+      - "traefik.http.routers.spotify-web.middlewares=umami@docker"
       - "traefik.http.routers.spotify-web.entrypoints=websecure"
       - "traefik.http.routers.spotify-web.tls.certresolver=cloudflare"
       - "traefik.http.services.spotify-web.loadbalancer.server.port=3000"


### PR DESCRIPTION
Add `umami@docker` middleware to all 13 Traefik routers for server-side analytics tracking.

**Services with existing middlewares** (appended):
- dozzle, nextflux, rsshub, s-pdf, traefik-dashboard

**Services without middlewares** (added):
- bytestash, immich, karakeep, miniflux, n8n, paperless, spotify-server, spotify-web

**Excluded:**
- umami (tracking itself is pointless)
- whoami (test service)

⚠️ After merge, all stacks need redeployment via Komodo for the middleware to take effect.