### PR TITLE
feat: add umami as default middleware on websecure entrypoint

### DIFF
--- a/stacks/traefik/compose.yaml
+++ b/stacks/traefik/compose.yaml
@@ -12,6 +12,9 @@ services:
       - --entrypoints.web.address=:80
       - --entrypoints.websecure.address=:443
 
+      # Default middlewares for websecure
+      - --entrypoints.websecure.http.middlewares=umami@docker
+
       # HTTP to HTTPS redirect
       - --entrypoints.web.http.redirections.entrypoint.to=websecure
       - --entrypoints.web.http.redirections.entrypoint.scheme=https


### PR DESCRIPTION
Set `umami@docker` as a default middleware on the `websecure` entrypoint instead of adding it to every router individually.

One line change — automatically applies server-side analytics to all HTTPS routers, present and future.

Replaces #82.