### PR TITLE
Add k8s.ravil.space subdomain routing and TLS support

### DIFF
--- a/k8s/apps/internal/dozzle/http-route.yaml
+++ b/k8s/apps/internal/dozzle/http-route.yaml
@@ -10,7 +10,7 @@ spec:
     - name: internal
       namespace: gateway
   hostnames:
-    - "dozzle.ravil.space"
+    - "dozzle.k8s.ravil.space"
   rules:
     - backendRefs:
         - name: dozzle-oauth2-proxy

--- a/k8s/infra/network/gateway/cert-ravilspace.yaml
+++ b/k8s/infra/network/gateway/cert-ravilspace.yaml
@@ -7,6 +7,7 @@ spec:
   dnsNames:
     - "*.ravil.space"
     - "*.home.ravil.space"
+    - "*.k8s.ravil.space"
   issuerRef:
     group: cert-manager.io
     kind: ClusterIssuer

--- a/k8s/infra/network/gateway/gw-external.yaml
+++ b/k8s/infra/network/gateway/gw-external.yaml
@@ -22,6 +22,17 @@ spec:
           from: All
     - protocol: HTTPS
       port: 443
+      name: https-gateway-k8s
+      hostname: "*.k8s.ravil.space"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: cert-ravilspace
+      allowedRoutes:
+        namespaces:
+          from: All
+    - protocol: HTTPS
+      port: 443
       name: https-gateway-home
       hostname: "*.home.ravil.space"
       tls:

--- a/k8s/infra/network/gateway/gw-internal.yaml
+++ b/k8s/infra/network/gateway/gw-internal.yaml
@@ -22,6 +22,17 @@ spec:
           from: All
     - protocol: HTTPS
       port: 443
+      name: https-gateway-k8s
+      hostname: "*.k8s.ravil.space"
+      tls:
+        certificateRefs:
+          - kind: Secret
+            name: cert-ravilspace
+      allowedRoutes:
+        namespaces:
+          from: All
+    - protocol: HTTPS
+      port: 443
       name: https-domain-gateway
       hostname: kube.ravil.space
       tls:

--- a/terraform/modules/traefik/configs/tcp_routers.yaml
+++ b/terraform/modules/traefik/configs/tcp_routers.yaml
@@ -10,7 +10,7 @@ tcp:
       rule: >-
         HostSNI(`argocd.ravil.space`)
         || HostSNI(`glance.ravil.space`)
-        || HostSNI(`dozzle.ravil.space`)
+        || HostSNI(`dozzle.k8s.ravil.space`)
         || HostSNI(`it-tools.ravil.space`)
         || HostSNI(`inbox-zero.ravil.space`)
         || HostSNI(`changedetection.ravil.space`)


### PR DESCRIPTION
## Summary
This PR adds support for the `*.k8s.ravil.space` subdomain across the Kubernetes gateway infrastructure and updates related routing configurations to use the new subdomain.

## Key Changes
- **Gateway Configuration**: Added HTTPS listener on port 443 for `*.k8s.ravil.space` hostname to both external and internal gateways with TLS certificate reference
- **Certificate Management**: Extended the `cert-ravilspace` certificate to include `*.k8s.ravil.space` DNS name alongside existing `*.ravil.space` and `*.home.ravil.space` entries
- **Service Routing**: 
  - Updated Dozzle HTTPRoute hostname from `dozzle.ravil.space` to `dozzle.k8s.ravil.space`
  - Updated Traefik TCP router SNI rule to route `dozzle.k8s.ravil.space` instead of `dozzle.ravil.space`

## Implementation Details
- Both gateway configurations (external and internal) receive identical HTTPS listener configurations for the new subdomain
- The TLS configuration references the existing `cert-ravilspace` secret, which now covers the new subdomain via wildcard certificate
- Dozzle service is migrated to the new k8s subdomain namespace while maintaining the same backend service reference

https://claude.ai/code/session_016ArBM42fSb1JCGVnaT7HfH