### PR TITLE
feat: add Grafana OTEL LGTM stack with cAdvisor

### DIFF
--- a/stacks/grafana-lgtm/compose.yaml
+++ b/stacks/grafana-lgtm/compose.yaml
@@ -1,0 +1,46 @@
+services:
+  lgtm:
+    image: grafana/otel-lgtm:latest
+    container_name: grafana-lgtm
+    restart: unless-stopped
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GF_ADMIN_USER}
+      GF_SECURITY_ADMIN_PASSWORD: ${GF_ADMIN_PASSWORD}
+    volumes:
+      - grafana-data:/data
+      - ./prometheus.yaml:/otel-lgtm/prometheus.yaml
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana_beta.ravil.space`)"
+      - "traefik.http.routers.grafana.entrypoints=websecure"
+      - "traefik.http.routers.grafana.tls.certresolver=cloudflare"
+      - "traefik.http.routers.grafana.middlewares=oidc-auth@docker"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+      - "traefik.docker.network=traefik_default"
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:latest
+    container_name: cadvisor
+    restart: unless-stopped
+    privileged: true
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker/:/var/lib/docker:ro
+      - /dev/disk/:/dev/disk:ro
+    devices:
+      - /dev/kmsg
+
+volumes:
+  grafana-data:
+
+networks:
+  default:
+    name: grafana-lgtm_default
+  traefik:
+    name: traefik_default
+    external: true

--- a/stacks/grafana-lgtm/prometheus.yaml
+++ b/stacks/grafana-lgtm/prometheus.yaml
@@ -1,0 +1,36 @@
+---
+global:
+  scrape_interval: 15s
+  scrape_native_histograms: true
+otlp:
+  keep_identifying_resource_attributes: true
+  promote_resource_attributes:
+    - service.instance.id
+    - service.name
+    - service.namespace
+    - service.version
+    - cloud.availability_zone
+    - cloud.region
+    - container.name
+    - deployment.environment
+    - deployment.environment.name
+    - k8s.cluster.name
+    - k8s.container.name
+    - k8s.cronjob.name
+    - k8s.daemonset.name
+    - k8s.deployment.name
+    - k8s.job.name
+    - k8s.namespace.name
+    - k8s.node.name
+    - k8s.pod.name
+    - k8s.replicaset.name
+    - k8s.statefulset.name
+    - host.name
+storage:
+  tsdb:
+    out_of_order_time_window: 10m
+
+scrape_configs:
+  - job_name: "cadvisor"
+    static_configs:
+      - targets: ["cadvisor:8080"]


### PR DESCRIPTION
## What
- Grafana OTEL LGTM (Grafana + Prometheus + Loki + Tempo + OTel Collector) all-in-one
- cAdvisor for Docker container metrics
- Prometheus scrapes cAdvisor every 15s

## Routing
- Traefik → `grafana_beta.ravil.space` with OIDC (Pocket ID)

## Required
- Komodo env vars: `GF_ADMIN_USER`, `GF_ADMIN_PASSWORD`
- Cloudflare DNS: `grafana_beta.ravil.space` → 192.168.1.166