### PR TITLE
fix: upgrade kubernetes_namespace to kubernetes_namespace_v1 and remove unused Talos IP vars

### DIFF
--- a/.github/workflows/terraform.yaml
+++ b/.github/workflows/terraform.yaml
@@ -87,8 +87,6 @@ jobs:
       TF_VAR_proxmox_endpoint: "https://192.168.1.100:8006"
       TF_VAR_proxmox_api_token: "${{ secrets.PM_API_TOKEN_ID }}=${{ secrets.PM_API_TOKEN_SECRET }}"
       TF_VAR_default_gateway: "${{ secrets.TF_VAR_DEFAULT_GATEWAY }}"
-      TF_VAR_talos_cp_01_ip_addr: "${{ secrets.TF_VAR_TALOS_CP_01_IP }}"
-      TF_VAR_talos_worker_01_ip_addr: "${{ secrets.TF_VAR_TALOS_WORKER_01_IP }}"
       TF_VAR_datastore_id: "${{ secrets.TF_VAR_DATASTORE_ID }}"
 
     steps:

--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,5 +1,5 @@
 # create namespace and enforce it to priveleged
-resource "kubernetes_namespace" "monitoring" {
+resource "kubernetes_namespace_v1" "monitoring" {
   metadata {
     name = var.namespace
     labels = {
@@ -13,7 +13,7 @@ resource "helm_release" "grafana-k8s-monitoring" {
   name       = "grafana-k8s-monitoring"
   repository = "https://grafana.github.io/helm-charts"
   chart      = "k8s-monitoring"
-  namespace  = kubernetes_namespace.monitoring.metadata.0.name
+  namespace  = kubernetes_namespace_v1.monitoring.metadata.0.name
   version    = "3.6.1"
   atomic     = true
   timeout    = 300

--- a/terraform/modules/proxmox-csi-plugin/main.tf
+++ b/terraform/modules/proxmox-csi-plugin/main.tf
@@ -26,7 +26,7 @@ resource "proxmox_virtual_environment_user_token" "kubernetes-csi-token" {
   privileges_separation = false
 }
 
-resource "kubernetes_namespace" "csi-proxmox" {
+resource "kubernetes_namespace_v1" "csi-proxmox" {
   metadata {
     name = "csi-proxmox"
     labels = {
@@ -40,7 +40,7 @@ resource "kubernetes_namespace" "csi-proxmox" {
 resource "kubernetes_secret" "proxmox-csi-plugin" {
   metadata {
     name      = "proxmox-csi-plugin"
-    namespace = kubernetes_namespace.csi-proxmox.id
+    namespace = kubernetes_namespace_v1.csi-proxmox.id
   }
 
   data = {

--- a/terraform/modules/sealed-secrets/main.tf
+++ b/terraform/modules/sealed-secrets/main.tf
@@ -1,11 +1,11 @@
-resource "kubernetes_namespace" "sealed-secrets" {
+resource "kubernetes_namespace_v1" "sealed-secrets" {
   metadata {
     name = "sealed-secrets"
   }
 }
 
 resource "kubernetes_secret" "sealed-secrets-key" {
-  depends_on = [kubernetes_namespace.sealed-secrets]
+  depends_on = [kubernetes_namespace_v1.sealed-secrets]
   type       = "kubernetes.io/tls"
 
   metadata {


### PR DESCRIPTION
## Summary

- Replaces deprecated `kubernetes_namespace` resource with `kubernetes_namespace_v1` in `monitoring`, `proxmox-csi-plugin`, and `sealed-secrets` Terraform modules
- Removes unused `TF_VAR_talos_cp_01_ip_addr` and `TF_VAR_talos_worker_01_ip_addr` environment variables from the CI workflow

## Test plan

- [ ] Verify Terraform plan succeeds with the updated resource types
- [ ] Confirm CI workflow runs without referencing the removed variables
- [ ] Validate that existing namespaces are not recreated (state references updated correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)