### PR TITLE
docs: add Komodo service workflow and update stack inventory

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,8 +46,16 @@ Traffic enters via a Traefik instance that does TLS passthrough to two backends:
 - **Adding a new Komodo service**: no change needed in `tcp_routers.yaml`
 - **Adding a new K8s service**: add its hostname to `k8s-tcp-router` rule
 
-K8s domains (as of last update): `argocd`, `glance`, `dozzle`, `it-tools`, `inbox-zero`,
+K8s domains (as of last update): `argocd`, `glance`, `dozzle.k8s`, `it-tools`, `inbox-zero`,
 `changedetection`, `grafana`, `ha`, `openwebui`, `pocketid`, `proxmox` (all `.ravil.space`)
+
+## Adding a New Service (Docker/Komodo)
+
+1. Create `stacks/{name}/compose.yaml` with Traefik labels
+   - Hardcode domain as `ravil.space` in labels (not via env var)
+2. Add secrets to Komodo Variables/Secrets (never commit secrets to repo)
+3. Create Komodo stack pointing to this git repo
+4. Configure OIDC (Traefik middleware or native) — **mandatory for public services**
 
 ## Best Practices
 - Document major components in README.md

--- a/README.md
+++ b/README.md
@@ -53,6 +53,9 @@ deployment.
 - [Dozzle](https://dozzle.dev/) - Container log viewer.
 - [Traefik](https://traefik.io/) - Reverse proxy for Docker stacks.
 - [GitHub Runner](https://github.com/actions/runner) - Self-hosted GitHub Actions runner.
+- [Grafana LGTM](https://grafana.com/) - Self-hosted OTEL observability stack (Loki, Grafana, Tempo, Mimir) with cAdvisor.
+- [Ntfy](https://ntfy.sh/) - Push notification service.
+- [Umami](https://umami.is/) - Privacy-focused web analytics.
 
 ---
 

--- a/stacks/README.md
+++ b/stacks/README.md
@@ -50,3 +50,10 @@ Secrets are stored in Komodo Variables/Secrets — never in this repo.
 ### your_spotify
 - `SPOTIFY_CLIENT_ID`
 - `SPOTIFY_CLIENT_SECRET`
+
+### umami
+- `UMAMI_DB_PASSWORD`
+- `UMAMI_APP_SECRET`
+
+### grafana-lgtm
+- `GF_ADMIN_PASSWORD`


### PR DESCRIPTION
## Summary
- Add step-by-step guide for adding new Docker/Komodo services to `CLAUDE.md`
- Fix `dozzle.k8s` domain entry in Traefik TCP routing docs
- Add Grafana LGTM, Ntfy, and Umami to `README.md` and `stacks/README.md` secret docs

## Test plan
- [ ] Review CLAUDE.md for accuracy of Komodo service workflow
- [ ] Verify stacks/README.md secret entries match deployed stacks

🤖 Generated with [Claude Code](https://claude.com/claude-code)