### PR TITLE
ci: auto-create new stacks in Komodo on deploy

### DIFF
--- a/.github/workflows/komodo-deploy.yaml
+++ b/.github/workflows/komodo-deploy.yaml
@@ -18,9 +18,17 @@ jobs:
       - name: Detect changed stacks
         id: changed
         run: |
-          stacks=$(git diff --name-only HEAD~1 HEAD -- stacks/ | cut -d'/' -f2 | sort -u | tr '\n' ' ')
+          # Get changed dirs under stacks/, filter to only those with a compose file
+          candidates=$(git diff --name-only HEAD~1 HEAD -- stacks/ | grep '/' | cut -d'/' -f2 | sort -u)
+          stacks=""
+          for s in $candidates; do
+            if [ -f "stacks/$s/compose.yaml" ] || [ -f "stacks/$s/compose.yml" ] || [ -f "stacks/$s/docker-compose.yaml" ] || [ -f "stacks/$s/docker-compose.yml" ]; then
+              stacks="$stacks $s"
+            fi
+          done
+          stacks=$(echo "$stacks" | xargs)
           echo "stacks=$stacks" >> "$GITHUB_OUTPUT"
-          echo "Changed stacks: $stacks"
+          echo "Changed stacks: ${stacks:-none}"
 
       - name: Deploy to Komodo
         if: steps.changed.outputs.stacks != ''

--- a/.github/workflows/komodo-deploy.yaml
+++ b/.github/workflows/komodo-deploy.yaml
@@ -28,9 +28,38 @@ jobs:
           KOMODO_API: http://192.168.1.166:9120
           KOMODO_KEY: ${{ secrets.KOMODO_API_KEY }}
           KOMODO_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+          KOMODO_SERVER_ID: ${{ secrets.KOMODO_SERVER_ID }}
         run: |
           for stack in ${{ steps.changed.outputs.stacks }}; do
             echo "🚀 Deploying $stack..."
+
+            # Check if stack exists in Komodo
+            existing=$(curl -sf -X POST "$KOMODO_API/read" \
+              -H "X-Api-Key: $KOMODO_KEY" \
+              -H "X-Api-Secret: $KOMODO_SECRET" \
+              -H "Content-Type: application/json" \
+              -d "{\"type\": \"ListStacks\", \"params\": {}}" \
+              | jq -r ".[] | select(.name == \"$stack\") | .name")
+
+            if [ -z "$existing" ]; then
+              echo "📦 Stack $stack not found in Komodo, creating..."
+              # Create stack
+              stack_id=$(curl -sf -X POST "$KOMODO_API/write" \
+                -H "X-Api-Key: $KOMODO_KEY" \
+                -H "X-Api-Secret: $KOMODO_SECRET" \
+                -H "Content-Type: application/json" \
+                -d "{\"type\": \"CreateStack\", \"params\": {\"name\": \"$stack\"}}" \
+                | jq -r '._id."$oid"')
+
+              # Configure stack with repo and server
+              curl -sf -X POST "$KOMODO_API/write" \
+                -H "X-Api-Key: $KOMODO_KEY" \
+                -H "X-Api-Secret: $KOMODO_SECRET" \
+                -H "Content-Type: application/json" \
+                -d "{\"type\": \"UpdateStack\", \"params\": {\"id\": \"$stack_id\", \"config\": {\"server_id\": \"$KOMODO_SERVER_ID\", \"repo\": \"ravilushqa/homelab\", \"branch\": \"main\", \"clone_path\": \"stacks/$stack\"}}}"
+              echo "✅ Stack $stack created and configured"
+            fi
+
             # Pull latest from git
             curl -sf -X POST "$KOMODO_API/execute" \
               -H "X-Api-Key: $KOMODO_KEY" \


### PR DESCRIPTION
## What
When a new stack directory is added to `stacks/` and merged to main, CI now auto-creates and configures the stack in Komodo before pulling and deploying.

## How
1. `ListStacks` → check if stack name exists
2. If not → `CreateStack` + `UpdateStack` (set server, repo, clone_path)
3. Then proceed with existing `PullStack` + `DeployStack`