### PR TITLE
fix: add moved blocks for kubernetes_namespace → kubernetes_namespace_v1

### DIFF
--- a/terraform/modules/monitoring/main.tf
+++ b/terraform/modules/monitoring/main.tf
@@ -1,3 +1,8 @@
+moved {
+  from = kubernetes_namespace.monitoring
+  to   = kubernetes_namespace_v1.monitoring
+}
+
 # create namespace and enforce it to priveleged
 resource "kubernetes_namespace_v1" "monitoring" {
   metadata {

--- a/terraform/modules/proxmox-csi-plugin/main.tf
+++ b/terraform/modules/proxmox-csi-plugin/main.tf
@@ -26,6 +26,11 @@ resource "proxmox_virtual_environment_user_token" "kubernetes-csi-token" {
   privileges_separation = false
 }
 
+moved {
+  from = kubernetes_namespace.csi-proxmox
+  to   = kubernetes_namespace_v1.csi-proxmox
+}
+
 resource "kubernetes_namespace_v1" "csi-proxmox" {
   metadata {
     name = "csi-proxmox"

--- a/terraform/modules/sealed-secrets/main.tf
+++ b/terraform/modules/sealed-secrets/main.tf
@@ -1,3 +1,8 @@
+moved {
+  from = kubernetes_namespace.sealed-secrets
+  to   = kubernetes_namespace_v1.sealed-secrets
+}
+
 resource "kubernetes_namespace_v1" "sealed-secrets" {
   metadata {
     name = "sealed-secrets"


### PR DESCRIPTION
Terraform was trying to destroy and recreate namespaces because the resource type changed from `kubernetes_namespace` to `kubernetes_namespace_v1` without telling the state about it.

Adds `moved` blocks to:
- `monitoring`
- `sealed-secrets`
- `proxmox-csi-plugin`

This will make Terraform update the state in-place instead of destroy+create.