### PR TITLE
feat: add openclaw dashboard stack with OIDC auth via Traefik

### DIFF
--- a/stacks/openclaw/compose.yaml
+++ b/stacks/openclaw/compose.yaml
@@ -1,0 +1,24 @@
+services:
+  # Dummy container — labels only. Traefik routes to external OpenClaw gateway on 192.168.1.65.
+  openclaw-router:
+    image: traefik/whoami
+    container_name: openclaw-router
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+
+      # Router
+      - "traefik.http.routers.openclaw.rule=Host(`openclaw.ravil.space`)"
+      - "traefik.http.routers.openclaw.entrypoints=websecure"
+      - "traefik.http.routers.openclaw.tls.certresolver=cloudflare"
+      - "traefik.http.routers.openclaw.middlewares=oidc-auth@docker,openclaw-user-header@docker"
+      - "traefik.http.routers.openclaw.service=openclaw-svc"
+
+      # External service
+      - "traefik.http.services.openclaw-svc.loadbalancer.server.url=http://192.168.1.65:18789"
+
+      # WebSocket support
+      - "traefik.http.services.openclaw-svc.loadbalancer.passHostHeader=true"
+
+      # Add X-Forwarded-User header for OpenClaw trusted-proxy auth
+      - "traefik.http.middlewares.openclaw-user-header.headers.customrequestheaders.X-Forwarded-User=ravilushqa"


### PR DESCRIPTION
## What
Exposes OpenClaw dashboard at `openclaw.ravil.space` behind Pocket ID OIDC auth.

## How
- Dummy container with Traefik labels routing to `192.168.1.65:18789`
- Protected by existing `oidc-auth@docker` middleware (Pocket ID)
- Adds `X-Forwarded-User: ravilushqa` header for OpenClaw trusted-proxy auth

## Also needed
- Add DNS record `openclaw.ravil.space` → Cloudflare (proxied)
- OpenClaw gateway config already updated to `trusted-proxy` mode (applied separately)