### PR TITLE
feat: add openclaw stack to komodo sync

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -244,3 +244,14 @@ server_id = "Local"
 repo = "ravilushqa/homelab"
 branch = "main"
 run_directory = "stacks/ntfy"
+
+[[stack]]
+name = "openclaw"
+description = "OpenClaw AI gateway — exposed via Traefik + Pocket ID OIDC"
+tags = ["infra"]
+deploy = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "stacks/openclaw"


### PR DESCRIPTION
Adds `openclaw` stack declaration to `komodo/stacks.toml` so it is tracked via GitOps like all other stacks.