### PR TITLE
fix: add traefik_default network to proxmox and openclaw routers

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -255,3 +255,14 @@ server_id = "Local"
 repo = "ravilushqa/homelab"
 branch = "main"
 run_directory = "stacks/openclaw"
+
+[[stack]]
+name = "proxmox"
+description = "Proxmox dashboard — exposed via Traefik + Pocket ID OIDC"
+tags = ["infra"]
+deploy = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "stacks/proxmox"

--- a/stacks/proxmox/compose.yaml
+++ b/stacks/proxmox/compose.yaml
@@ -14,9 +14,5 @@ services:
       - "traefik.http.routers.proxmox.middlewares=oidc-auth@docker"
       - "traefik.http.routers.proxmox.service=proxmox-svc"
 
-      # External service (Proxmox uses HTTPS with self-signed cert)
+      # External service
       - "traefik.http.services.proxmox-svc.loadbalancer.server.url=https://192.168.1.100:8006"
-      - "traefik.http.services.proxmox-svc.loadbalancer.serverstransport=proxmox-transport@docker"
-
-      # Skip TLS verification for Proxmox self-signed cert
-      - "traefik.http.serverstransports.proxmox-transport.insecureskipverify=true"

--- a/stacks/proxmox/compose.yaml
+++ b/stacks/proxmox/compose.yaml
@@ -1,0 +1,22 @@
+services:
+  # Dummy container — labels only. Traefik routes to Proxmox at 192.168.1.100:8006.
+  proxmox-router:
+    image: traefik/whoami
+    container_name: proxmox-router
+    restart: unless-stopped
+    labels:
+      - "traefik.enable=true"
+
+      # Router
+      - "traefik.http.routers.proxmox.rule=Host(`proxmox.ravil.space`)"
+      - "traefik.http.routers.proxmox.entrypoints=websecure"
+      - "traefik.http.routers.proxmox.tls.certresolver=cloudflare"
+      - "traefik.http.routers.proxmox.middlewares=oidc-auth@docker"
+      - "traefik.http.routers.proxmox.service=proxmox-svc"
+
+      # External service (Proxmox uses HTTPS with self-signed cert)
+      - "traefik.http.services.proxmox-svc.loadbalancer.server.url=https://192.168.1.100:8006"
+      - "traefik.http.services.proxmox-svc.loadbalancer.serverstransport=proxmox-transport@docker"
+
+      # Skip TLS verification for Proxmox self-signed cert
+      - "traefik.http.serverstransports.proxmox-transport.insecureskipverify=true"

--- a/stacks/proxmox/compose.yaml
+++ b/stacks/proxmox/compose.yaml
@@ -4,6 +4,8 @@ services:
     image: traefik/whoami
     container_name: proxmox-router
     restart: unless-stopped
+    networks:
+      - traefik_default
     labels:
       - "traefik.enable=true"
 
@@ -16,3 +18,7 @@ services:
 
       # External service
       - "traefik.http.services.proxmox-svc.loadbalancer.server.url=https://192.168.1.100:8006"
+
+networks:
+  traefik_default:
+    external: true


### PR DESCRIPTION
Traefik не видит labels если контейнер не в той же сети. Добавил `traefik_default` network.