### PR TITLE
fix: add traefik_default network to openclaw router

### DIFF
--- a/stacks/openclaw/compose.yaml
+++ b/stacks/openclaw/compose.yaml
@@ -4,6 +4,8 @@ services:
     image: traefik/whoami
     container_name: openclaw-router
     restart: unless-stopped
+    networks:
+      - traefik_default
     labels:
       - "traefik.enable=true"
 
@@ -22,3 +24,7 @@ services:
 
       # Add X-Forwarded-User header for OpenClaw trusted-proxy auth
       - "traefik.http.middlewares.openclaw-user-header.headers.customrequestheaders.X-Forwarded-User=ravilushqa"
+
+networks:
+  traefik_default:
+    external: true


### PR DESCRIPTION
Traefik не видит labels если контейнер не в той же сети.