### PR TITLE
fix: enable global insecureSkipVerify in Traefik for Proxmox backend

### DIFF
--- a/stacks/proxmox/compose.yaml
+++ b/stacks/proxmox/compose.yaml
@@ -16,10 +16,8 @@ services:
       - "traefik.http.routers.proxmox.middlewares=oidc-auth@docker"
       - "traefik.http.routers.proxmox.service=proxmox-svc"
 
-      # External service (skip TLS verify — Proxmox self-signed cert)
+      # External service
       - "traefik.http.services.proxmox-svc.loadbalancer.server.url=https://192.168.1.100:8006"
-      - "traefik.http.services.proxmox-svc.loadbalancer.serverstransport=proxmox-transport@docker"
-      - "traefik.http.serverstransports.proxmox-transport.insecureskipverify=true"
 
 networks:
   traefik_default:

--- a/stacks/traefik/compose.yaml
+++ b/stacks/traefik/compose.yaml
@@ -38,6 +38,7 @@ services:
       # Global settings
       - --global.checknewversion=false
       - --global.sendanonymoususage=false
+      - --serversTransport.insecureSkipVerify=true
 
       # OIDC auth plugin
       - --experimental.plugins.traefik-oidc-auth.modulename=github.com/sevensolutions/traefik-oidc-auth


### PR DESCRIPTION
`serverstransports` labels не работают с Docker provider в Traefik v3. Включаем глобально `--serversTransport.insecureSkipVerify=true` чтобы Traefik мог проксировать на Proxmox с self-signed сертом.