### PR TITLE
fix: use file provider serversTransport for Proxmox TLS

### DIFF
--- a/stacks/proxmox/compose.yaml
+++ b/stacks/proxmox/compose.yaml
@@ -16,10 +16,9 @@ services:
       - "traefik.http.routers.proxmox.middlewares=oidc-auth@docker"
       - "traefik.http.routers.proxmox.service=proxmox-svc"
 
-      # External service (skip TLS verify — Proxmox self-signed cert)
+      # External service with custom transport (skip TLS verify for self-signed cert)
       - "traefik.http.services.proxmox-svc.loadbalancer.server.url=https://192.168.1.100:8006"
-      - "traefik.http.services.proxmox-svc.loadbalancer.serverstransport=proxmox-transport@docker"
-      - "traefik.http.serverstransports.proxmox-transport.insecureskipverify=true"
+      - "traefik.http.services.proxmox-svc.loadbalancer.serverstransport=proxmox-transport@file"
 
 networks:
   traefik_default:

--- a/stacks/traefik/compose.yaml
+++ b/stacks/traefik/compose.yaml
@@ -38,6 +38,7 @@ services:
       # Global settings
       - --global.checknewversion=false
       - --global.sendanonymoususage=false
+      - --providers.file.filename=/etc/traefik/dynamic.yml
 
       # OIDC auth plugin
       - --experimental.plugins.traefik-oidc-auth.modulename=github.com/sevensolutions/traefik-oidc-auth
@@ -57,6 +58,7 @@ services:
 
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
+      - ./dynamic.yml:/etc/traefik/dynamic.yml:ro
       - letsencrypt:/letsencrypt
 
     labels:

--- a/stacks/traefik/dynamic.yml
+++ b/stacks/traefik/dynamic.yml
@@ -1,0 +1,4 @@
+http:
+  serversTransports:
+    proxmox-transport:
+      insecureSkipVerify: true


### PR DESCRIPTION
Adds a file provider with `dynamic.yml` to Traefik, defining a `proxmox-transport` with `insecureSkipVerify: true`. The proxmox stack uses `@file` suffix instead of `@docker` for the serversTransport reference.

`serverstransports` cannot be defined via Docker labels in Traefik v3 — file provider is the correct approach.