### PR TITLE
feat: add hooks.ravil.space for webhook ingress

### DIFF
--- a/k8s/apps/external/hooks/kustomization.yaml
+++ b/k8s/apps/external/hooks/kustomization.yaml
@@ -1,0 +1,66 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - namespace.yaml
+
+components:
+  - ../../../components/external-service
+
+patches:
+  # Update Service
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: hooks
+      - op: replace
+        path: /metadata/namespace
+        value: hooks
+      - op: replace
+        path: /spec/ports/0/port
+        value: 18789
+    target:
+      kind: Service
+      name: service-name
+
+  # Update EndpointSlice
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: hooks
+      - op: replace
+        path: /metadata/namespace
+        value: hooks
+      - op: replace
+        path: /metadata/labels/kubernetes.io~1service-name
+        value: hooks
+      - op: replace
+        path: /ports/0/port
+        value: 18789
+      - op: replace
+        path: /endpoints/0/addresses/0
+        value: 192.168.1.65
+    target:
+      kind: EndpointSlice
+      name: service-name
+
+  # Update HTTPRoute
+  - patch: |-
+      - op: replace
+        path: /metadata/name
+        value: hooks
+      - op: replace
+        path: /metadata/namespace
+        value: hooks
+      - op: replace
+        path: /spec/hostnames/0
+        value: hooks.ravil.space
+      - op: replace
+        path: /spec/rules/0/backendRefs/0/name
+        value: hooks
+      - op: replace
+        path: /spec/rules/0/backendRefs/0/port
+        value: 18789
+    target:
+      kind: HTTPRoute
+      name: service-name

--- a/k8s/apps/external/hooks/namespace.yaml
+++ b/k8s/apps/external/hooks/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: hooks


### PR DESCRIPTION
Adds `hooks.ravil.space` → OpenClaw gateway (port 18789) без auth middleware.

Используется для Telnyx voice call webhooks.