### PR TITLE
feat: enable auto_update for openclaw stack in Komodo

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -250,6 +250,7 @@ name = "openclaw"
 description = "OpenClaw AI gateway — exposed via Traefik + Pocket ID OIDC"
 tags = ["infra"]
 deploy = true
+auto_update = true
 [stack.config]
 server_id = "Local"
 repo = "ravilushqa/homelab"


### PR DESCRIPTION
Adds `auto_update = true` to the openclaw stack config so Komodo automatically redeploys when the repo changes.