### PR TITLE
feat: expose paperless-gpt via Traefik at paperless-gpt.ravil.space

### DIFF
--- a/stacks/paperless-ngx/compose.yaml
+++ b/stacks/paperless-ngx/compose.yaml
@@ -75,6 +75,16 @@ services:
   paperless-gpt:
     image: icereed/paperless-gpt:latest
     restart: unless-stopped
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.paperless-gpt.rule=Host(`paperless-gpt.ravil.space`)"
+      - "traefik.http.routers.paperless-gpt.entrypoints=websecure"
+      - "traefik.http.routers.paperless-gpt.tls.certresolver=cloudflare"
+      - "traefik.http.services.paperless-gpt.loadbalancer.server.port=8080"
+      - "traefik.docker.network=traefik_default"
     environment:
       PAPERLESS_BASE_URL: "http://webserver:8000"
       PAPERLESS_API_TOKEN: ${PAPERLESS_API_TOKEN}

--- a/stacks/paperless-ngx/compose.yaml
+++ b/stacks/paperless-ngx/compose.yaml
@@ -83,6 +83,7 @@ services:
       - "traefik.http.routers.paperless-gpt.rule=Host(`paperless-gpt.ravil.space`)"
       - "traefik.http.routers.paperless-gpt.entrypoints=websecure"
       - "traefik.http.routers.paperless-gpt.tls.certresolver=cloudflare"
+      - "traefik.http.routers.paperless-gpt.middlewares=oidc-auth@docker"
       - "traefik.http.services.paperless-gpt.loadbalancer.server.port=8080"
       - "traefik.docker.network=traefik_default"
     environment:


### PR DESCRIPTION
Adds Traefik labels and traefik network to the `paperless-gpt` service so it is accessible at https://paperless-gpt.ravil.space