### PR TITLE
fix: use traefik_default network name for actual budget

### DIFF
--- a/stacks/actual/compose.yaml
+++ b/stacks/actual/compose.yaml
@@ -26,4 +26,5 @@ volumes:
 networks:
   default:
   traefik:
+    name: traefik_default
     external: true


### PR DESCRIPTION
The `traefik` network is named `traefik_default` on this host (created by the traefik stack). Added `name: traefik_default` to fix deploy error:

```
network traefik declared as external, but could not be found
```