### PR TITLE
fix: add traefik.docker.network label for actual budget

### DIFF
--- a/stacks/actual/compose.yaml
+++ b/stacks/actual/compose.yaml
@@ -15,6 +15,7 @@ services:
       - traefik
     labels:
       "traefik.enable": "true"
+      "traefik.docker.network": "traefik_default"
       "traefik.http.routers.actual.rule": "Host(`actual.ravil.space`)"
       "traefik.http.routers.actual.entrypoints": "websecure"
       "traefik.http.routers.actual.tls.certresolver": "cloudflare"


### PR DESCRIPTION
Container has two networks (`actual_default` + `traefik_default`). Without `traefik.docker.network` label Traefik picks the wrong IP and cannot route traffic.