### PR TITLE
feat: add hr-breaker stack (AI resume optimizer)

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -291,6 +291,21 @@ TELNYX_PUBLIC_KEY = [[TELNYX_PUBLIC_KEY]]
 """
 
 [[stack]]
+name = "hr-breaker"
+description = "AI resume optimizer — Streamlit UI, WeasyPrint PDF output"
+tags = ["ai", "tools"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "komodo/stacks/hr-breaker"
+environment = """
+GEMINI_API_KEY = [[HR_BREAKER_GEMINI_API_KEY]]
+"""
+
+[[stack]]
 name = "actual"
 description = "Actual Budget - local-first personal finance"
 tags = ["finance"]

--- a/komodo/stacks/hr-breaker/compose.yaml
+++ b/komodo/stacks/hr-breaker/compose.yaml
@@ -1,0 +1,22 @@
+services:
+  hr-breaker:
+    image: hr-breaker:latest
+    container_name: hr-breaker
+    restart: unless-stopped
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+    networks:
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hr-breaker.rule=Host(`hr-breaker.ravil.space`)"
+      - "traefik.http.routers.hr-breaker.entrypoints=websecure"
+      - "traefik.http.routers.hr-breaker.tls.certresolver=cloudflare"
+      - "traefik.http.services.hr-breaker.loadbalancer.server.port=8501"
+      - "traefik.docker.network=traefik_default"
+      - "traefik.http.routers.hr-breaker.middlewares=oidc-auth@docker"
+
+networks:
+  traefik:
+    name: traefik_default
+    external: true


### PR DESCRIPTION
Adds hr-breaker — AI-powered resume optimizer with Streamlit UI.

- Image: `hr-breaker:latest` (built locally on .166 from https://github.com/btseytlin/hr-breaker)
- URL: https://hr-breaker.ravil.space
- Auth: OIDC (oidc-auth@docker)
- LLM: Gemini via `[[HR_BREAKER_GEMINI_API_KEY]]`