### PR TITLE
ci: add build-hr-breaker workflow

### DIFF
--- a/.github/workflows/build-hr-breaker.yml
+++ b/.github/workflows/build-hr-breaker.yml
@@ -1,0 +1,30 @@
+name: Build hr-breaker
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 4 * * 1'  # Every Monday 04:00 UTC — pick up upstream updates
+
+jobs:
+  build:
+    runs-on: self-hosted
+    steps:
+      - name: Pull latest hr-breaker source
+        run: |
+          cd ~/builds/hr-breaker
+          git pull
+
+      - name: Build Docker image
+        run: |
+          cd ~/builds/hr-breaker
+          docker build -t hr-breaker:latest .
+
+      - name: Redeploy via Komodo
+        run: |
+          source ~/.komodo.env
+          curl -sf -X POST "http://192.168.1.166:9120/execute" \
+            -H "Content-Type: application/json" \
+            -H "X-Api-Key: $KOMODO_API_KEY" \
+            -H "X-Api-Secret: $KOMODO_API_SECRET" \
+            -d '{"type":"DeployStack","params":{"stack":"hr-breaker"}}' \
+            | jq '{success: .success, status: .status}'

--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -291,6 +291,21 @@ TELNYX_PUBLIC_KEY = [[TELNYX_PUBLIC_KEY]]
 """
 
 [[stack]]
+name = "hr-breaker"
+description = "AI resume optimizer — Streamlit UI, WeasyPrint PDF output"
+tags = ["ai", "tools"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "komodo/stacks/hr-breaker"
+environment = """
+GEMINI_API_KEY = [[HR_BREAKER_GEMINI_API_KEY]]
+"""
+
+[[stack]]
 name = "actual"
 description = "Actual Budget - local-first personal finance"
 tags = ["finance"]

--- a/komodo/stacks/hr-breaker/compose.yaml
+++ b/komodo/stacks/hr-breaker/compose.yaml
@@ -1,0 +1,22 @@
+services:
+  hr-breaker:
+    image: hr-breaker:latest
+    container_name: hr-breaker
+    restart: unless-stopped
+    environment:
+      - GEMINI_API_KEY=${GEMINI_API_KEY}
+    networks:
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.hr-breaker.rule=Host(`hr-breaker.ravil.space`)"
+      - "traefik.http.routers.hr-breaker.entrypoints=websecure"
+      - "traefik.http.routers.hr-breaker.tls.certresolver=cloudflare"
+      - "traefik.http.services.hr-breaker.loadbalancer.server.port=8501"
+      - "traefik.docker.network=traefik_default"
+      - "traefik.http.routers.hr-breaker.middlewares=oidc-auth@docker"
+
+networks:
+  traefik:
+    name: traefik_default
+    external: true


### PR DESCRIPTION
GitHub Actions workflow to rebuild the `hr-breaker:latest` Docker image on the self-hosted runner.

- Triggers: `workflow_dispatch` (manual) + weekly schedule (Monday 04:00 UTC)
- Pulls latest from upstream (btseytlin/hr-breaker), rebuilds image, redeploys via Komodo API
- Komodo creds read from `~/.komodo.env` on the runner host