### PR TITLE
fix: add pull_policy=never for local hr-breaker image

### DIFF
--- a/komodo/stacks/hr-breaker/compose.yaml
+++ b/komodo/stacks/hr-breaker/compose.yaml
@@ -1,6 +1,7 @@
 services:
   hr-breaker:
     image: hr-breaker:latest
+    pull_policy: never
     container_name: hr-breaker
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Komodo tries to pull from Docker Hub before starting. Since `hr-breaker:latest` is built locally on the runner, `pull_policy: never` tells compose to use the local image.