### PR TITLE
fix: switch hr-breaker to OpenRouter

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -302,7 +302,7 @@ repo = "ravilushqa/homelab"
 branch = "main"
 run_directory = "komodo/stacks/hr-breaker"
 environment = """
-GEMINI_API_KEY = [[HR_BREAKER_GEMINI_API_KEY]]
+OPENROUTER_API_KEY = [[HR_BREAKER_OPENROUTER_API_KEY]]
 """
 
 [[stack]]

--- a/komodo/stacks/hr-breaker/compose.yaml
+++ b/komodo/stacks/hr-breaker/compose.yaml
@@ -5,7 +5,9 @@ services:
     container_name: hr-breaker
     restart: unless-stopped
     environment:
-      - GEMINI_API_KEY=${GEMINI_API_KEY}
+      - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
+      - PRO_MODEL=openrouter/google/gemini-2.5-pro-preview
+      - FLASH_MODEL=openrouter/google/gemini-2.0-flash-001
     networks:
       - traefik
     labels:


### PR DESCRIPTION
Replace Gemini API key with OpenRouter. Models: `gemini-2.5-pro-preview` (PRO) + `gemini-2.0-flash-001` (FLASH) via OpenRouter.