### PR TITLE
feat: add OpenHands autonomous coding agent

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -320,3 +320,18 @@ environment = """
 ACTUAL_OIDC_CLIENT_ID = [[ACTUAL_OIDC_CLIENT_ID]]
 ACTUAL_OIDC_CLIENT_SECRET = [[ACTUAL_OIDC_CLIENT_SECRET]]
 """
+[[stack]]
+name = "openhands"
+description = "OpenHands - AI autonomous coding agent"
+tags = ["ai", "tools"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "komodo/stacks/openhands"
+environment = """
+OPENHANDS_LLM_API_KEY = [[ANTHROPIC_API_KEY]]
+OPENHANDS_LLM_MODEL = anthropic/claude-sonnet-4-20250514
+"""

--- a/komodo/stacks/openhands/compose.yaml
+++ b/komodo/stacks/openhands/compose.yaml
@@ -1,0 +1,36 @@
+services:
+  openhands:
+    image: docker.all-hands.dev/all-hands-ai/openhands:0.9
+    container_name: openhands
+    restart: unless-stopped
+    environment:
+      SANDBOX_RUNTIME_CONTAINER_IMAGE: docker.all-hands.dev/all-hands-ai/runtime:0.9-nikolaik
+      LOG_ALL_EVENTS: "true"
+      LLM_MODEL: ${OPENHANDS_LLM_MODEL}
+      LLM_API_KEY: ${OPENHANDS_LLM_API_KEY}
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - openhands_state:/.openhands-state
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.openhands.rule=Host(`openhands.ravil.space`)"
+      - "traefik.http.routers.openhands.entrypoints=websecure"
+      - "traefik.http.routers.openhands.tls.certresolver=cloudflare"
+      - "traefik.http.services.openhands.loadbalancer.server.port=3000"
+      - "traefik.docker.network=traefik_default"
+      - "traefik.http.routers.openhands.middlewares=oidc-auth@docker"
+
+volumes:
+  openhands_state:
+
+networks:
+  default:
+    name: openhands_default
+  traefik:
+    name: traefik_default
+    external: true


### PR DESCRIPTION
Deploys [OpenHands](https://openhands.dev) as a self-hosted autonomous coding agent.

## What
- Docker stack at `komodo/stacks/openhands/`
- Registered in `komodo/stacks.toml`
- Accessible at https://openhands.ravil.space (protected by OIDC)
- Uses Claude Sonnet via `ANTHROPIC_API_KEY` Komodo variable

## Before merging
- [x] Add `ANTHROPIC_API_KEY` to Komodo variables (Settings → Variables)