### PR TITLE
fix: use ghcr.io registry for OpenHands images

### DIFF
--- a/komodo/stacks/openhands/compose.yaml
+++ b/komodo/stacks/openhands/compose.yaml
@@ -1,10 +1,10 @@
 services:
   openhands:
-    image: docker.all-hands.dev/all-hands-ai/openhands:0.9
+    image: ghcr.io/all-hands-ai/openhands:latest
     container_name: openhands
     restart: unless-stopped
     environment:
-      SANDBOX_RUNTIME_CONTAINER_IMAGE: docker.all-hands.dev/all-hands-ai/runtime:0.9-nikolaik
+      SANDBOX_RUNTIME_CONTAINER_IMAGE: ghcr.io/all-hands-ai/runtime:latest
       LOG_ALL_EVENTS: "true"
       LLM_MODEL: ${OPENHANDS_LLM_MODEL}
       LLM_API_KEY: ${OPENHANDS_LLM_API_KEY}

--- a/komodo/stacks/openhands/compose.yaml
+++ b/komodo/stacks/openhands/compose.yaml
@@ -1,10 +1,10 @@
 services:
   openhands:
-    image: ghcr.io/all-hands-ai/openhands:latest
+    image: ghcr.io/openhands/openhands:latest
     container_name: openhands
     restart: unless-stopped
     environment:
-      SANDBOX_RUNTIME_CONTAINER_IMAGE: ghcr.io/all-hands-ai/runtime:latest
+      SANDBOX_RUNTIME_CONTAINER_IMAGE: ghcr.io/openhands/runtime:latest
       LOG_ALL_EVENTS: "true"
       LLM_MODEL: ${OPENHANDS_LLM_MODEL}
       LLM_API_KEY: ${OPENHANDS_LLM_API_KEY}


### PR DESCRIPTION
`docker.all-hands.dev` no longer resolves (NXDOMAIN). OpenHands images have moved to `ghcr.io/all-hands-ai/`.

Changes:
- `openhands` image: `ghcr.io/all-hands-ai/openhands:latest`
- `SANDBOX_RUNTIME_CONTAINER_IMAGE`: `ghcr.io/all-hands-ai/runtime:latest`