### PR TITLE
Update hr-breaker models and service port configuration

### DIFF
--- a/komodo/stacks/hr-breaker/compose.yaml
+++ b/komodo/stacks/hr-breaker/compose.yaml
@@ -6,8 +6,8 @@ services:
     restart: unless-stopped
     environment:
       - OPENROUTER_API_KEY=${OPENROUTER_API_KEY}
-      - PRO_MODEL=openrouter/google/gemini-2.5-pro-preview
-      - FLASH_MODEL=openrouter/google/gemini-2.0-flash-001
+      - PRO_MODEL=openrouter/google/gemini-2.5-pro
+      - FLASH_MODEL=openrouter/google/gemini-2.5-flash
     networks:
       - traefik
     labels:

--- a/komodo/stacks/hr-breaker/compose.yaml
+++ b/komodo/stacks/hr-breaker/compose.yaml
@@ -15,7 +15,7 @@ services:
       - "traefik.http.routers.hr-breaker.rule=Host(`hr-breaker.ravil.space`)"
       - "traefik.http.routers.hr-breaker.entrypoints=websecure"
       - "traefik.http.routers.hr-breaker.tls.certresolver=cloudflare"
-      - "traefik.http.services.hr-breaker.loadbalancer.server.port=8501"
+      - "traefik.http.services.hr-breaker.loadbalancer.server.port=8899"
       - "traefik.docker.network=traefik_default"
       - "traefik.http.routers.hr-breaker.middlewares=oidc-auth@docker"
 


### PR DESCRIPTION
## Summary
Updated the hr-breaker service configuration to use newer Google Gemini models and changed the service port from 8501 to 8899.

## Key Changes
- **Model Updates:**
  - PRO_MODEL: `openrouter/google/gemini-2.5-pro-preview` → `openrouter/google/gemini-2.5-pro`
  - FLASH_MODEL: `openrouter/google/gemini-2.0-flash-001` → `openrouter/google/gemini-2.5-flash`
  
- **Port Configuration:**
  - Updated Traefik load balancer server port from `8501` to `8899`

## Implementation Details
These changes update the service to use the latest stable versions of Google's Gemini models (2.5 series) instead of preview/older versions, and adjust the internal service port configuration for the Traefik reverse proxy.

https://claude.ai/code/session_018qXProz1TVCaHvAFZh1kuA