### PR TITLE
chore: rename grafana-beta to grafana.ravil.space

### DIFF
--- a/komodo/stacks/grafana-lgtm/compose.yaml
+++ b/komodo/stacks/grafana-lgtm/compose.yaml
@@ -16,7 +16,7 @@ services:
       - traefik
     labels:
       - "traefik.enable=true"
-      - "traefik.http.routers.grafana.rule=Host(`grafana-beta.ravil.space`)"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.ravil.space`)"
       - "traefik.http.routers.grafana.entrypoints=websecure"
       - "traefik.http.routers.grafana.tls.certresolver=cloudflare"
       - "traefik.http.routers.grafana.middlewares=oidc-auth@docker"

--- a/terraform/modules/traefik/configs/tcp_routers.yaml
+++ b/terraform/modules/traefik/configs/tcp_routers.yaml
@@ -14,7 +14,6 @@ tcp:
         || HostSNI(`it-tools.ravil.space`)
         || HostSNI(`inbox-zero.ravil.space`)
         || HostSNI(`changedetection.ravil.space`)
-        || HostSNI(`grafana.ravil.space`)
         || HostSNI(`ha.ravil.space`)
         || HostSNI(`openwebui.ravil.space`)
         || HostSNI(`pocketid.ravil.space`)


### PR DESCRIPTION
- Update Host rule in grafana-lgtm compose.yaml: `grafana-beta.ravil.space` → `grafana.ravil.space`
- Remove `grafana.ravil.space` from k8s-tcp-router in Terraform (routes via Komodo catch-all now)