### PR TITLE
chore(immich): update to v2.7.5

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -145,8 +145,9 @@ run_directory = "komodo/stacks/immich"
 environment = """
 DB_DATABASE_NAME = [[DB_DATABASE_NAME]]
 DB_USERNAME = [[DB_USERNAME]]
-DB_PASSWORD = [[DB_PASSWORD]]
+DB_PASSWORD=***
 UPLOAD_LOCATION = [[UPLOAD_LOCATION]]
+IMMICH_VERSION=v2.7.5
 """
 
 [[stack]]

--- a/komodo/stacks/immich/compose.yaml
+++ b/komodo/stacks/immich/compose.yaml
@@ -5,8 +5,10 @@ services:
     container_name: immich_server
     image: ghcr.io/immich-app/immich-server:${IMMICH_VERSION:-release}
     volumes:
-      - ${UPLOAD_LOCATION}:/usr/src/app/upload
+      - ${UPLOAD_LOCATION}:/data
       - /etc/localtime:/etc/localtime:ro
+    env_file:
+      - .env
     environment:
       DB_HOSTNAME: database
       DB_USERNAME: ${DB_USERNAME}
@@ -35,6 +37,8 @@ services:
   immich-machine-learning:
     container_name: immich_machine_learning
     image: ghcr.io/immich-app/immich-machine-learning:${IMMICH_VERSION:-release}
+    env_file:
+      - .env
     volumes:
       - model-cache:/cache
     restart: always
@@ -43,48 +47,24 @@ services:
 
   redis:
     container_name: immich_redis
-    image: docker.io/redis:8.6-alpine
+    image: docker.io/valkey/valkey:9@sha256:3b55fbaa0cd93cf0d9d961f405e4dfcc70efe325e2d84da207a0a8e6d8fde4f9
     healthcheck:
       test: redis-cli ping || exit 1
     restart: always
 
   database:
     container_name: immich_postgres
-    image: docker.io/tensorchord/pgvecto-rs:pg14-v0.2.0
+    image: ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0@sha256:bcf63357191b76a916ae5eb93464d65c07511da41e3bf7a8416db519b40b1c23
     environment:
       POSTGRES_PASSWORD: ${DB_PASSWORD}
       POSTGRES_USER: ${DB_USERNAME}
       POSTGRES_DB: ${DB_DATABASE_NAME}
-      POSTGRES_INITDB_ARGS: --data-checksums
+      POSTGRES_INITDB_ARGS: '--data-checksums'
     volumes:
       - pgdata:/var/lib/postgresql/data
+    shm_size: 128mb
     healthcheck:
-      test: >-
-        pg_isready --dbname='${DB_DATABASE_NAME}'
-        --username='${DB_USERNAME}' || exit 1;
-        Chksum="$$(psql --dbname='${DB_DATABASE_NAME}'
-        --username='${DB_USERNAME}' --tuples-only --no-align
-        --command='SELECT COALESCE(SUM(checksum_failures), 0)
-        FROM pg_stat_database')";
-        echo "checksum failure count is $$Chksum";
-        [ "$$Chksum" = '0' ] || exit 1
-      interval: 5m
-      start_interval: 30s
-      start_period: 5m
-    command:
-      - postgres
-      - -c
-      - shared_preload_libraries=vectors.so
-      - -c
-      - 'search_path="$$user", public, vectors'
-      - -c
-      - logging_collector=on
-      - -c
-      - max_wal_size=2GB
-      - -c
-      - shared_buffers=512MB
-      - -c
-      - wal_compression=on
+      disable: false
     restart: always
 
 volumes:


### PR DESCRIPTION
## Changes

- **Database**: migrate from `pgvecto-rs` to VectorChord (`ghcr.io/immich-app/postgres:14-vectorchord0.4.3-pgvectors0.2.0`)
- **Redis → Valkey 9** (pinned digest)
- **Server volume mount**: `/usr/src/app/upload` → `/data`
- **env_file: .env** added to server and ML services
- Removed old postgres tuning `command:` block and custom healthcheck
- Added `shm_size: 128mb` to database
- Pinned `IMMICH_VERSION=v2.7.5`

## Migration Notes

VectorChord migration will trigger automatic reindexing (`clip_index`, `face_index`). May take minutes for large libraries.

**Do not downgrade below v2.5.6 after this update.**