### PR TITLE
perf: switch to gemini-2.0-flash-live-001 for lower latency

### DIFF
--- a/komodo/stacks/pipecat-call/bot.py
+++ b/komodo/stacks/pipecat-call/bot.py
@@ -88,7 +88,7 @@ WICHTIGSTE REGELN:
     llm = GeminiLiveLLMService(
         api_key=os.getenv("GOOGLE_API_KEY"),
         settings=GeminiLiveLLMService.Settings(
-            model="gemini-2.5-flash-native-audio-preview-09-2025",
+            model="gemini-2.0-flash-live-001",
             voice="Charon",
             system_instruction=system_instruction,
         ),


### PR DESCRIPTION
Switch model from gemini-2.5-flash-native-audio-preview-09-2025 to gemini-2.0-flash-live-001 to reduce TTFB latency.