### PR TITLE
fix: revert gemini model (2.0-flash-live-001 unsupported)

### DIFF
--- a/komodo/stacks/pipecat-call/bot.py
+++ b/komodo/stacks/pipecat-call/bot.py
@@ -88,7 +88,7 @@ WICHTIGSTE REGELN:
     llm = GeminiLiveLLMService(
         api_key=os.getenv("GOOGLE_API_KEY"),
         settings=GeminiLiveLLMService.Settings(
-            model="gemini-2.0-flash-live-001",
+            model="gemini-2.5-flash-native-audio-preview-09-2025",
             voice="Charon",
             system_instruction=system_instruction,
         ),


### PR DESCRIPTION
gemini-2.0-flash-live-001 not supported for bidiGenerateContent. Reverting to gemini-2.5-flash-native-audio-preview-09-2025.