### PR TITLE
feat: add actual-ai stack for AI transaction categorization

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -293,6 +293,7 @@ run_directory = "komodo/stacks/actual"
 environment = """
 ACTUAL_OIDC_CLIENT_ID = [[ACTUAL_OIDC_CLIENT_ID]]
 ACTUAL_OIDC_CLIENT_SECRET = [[ACTUAL_OIDC_CLIENT_SECRET]]
+ACTUAL_PASSWORD = [[ACTUAL_PASSWORD]]
 """
 [[stack]]
 name = "actual-ai"

--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -309,7 +309,7 @@ run_directory = "komodo/stacks/actual-ai"
 environment = """
 ACTUAL_AI_ACTUAL_PASSWORD = [[ACTUAL_AI_ACTUAL_PASSWORD]]
 ACTUAL_AI_BUDGET_ID = [[ACTUAL_AI_BUDGET_ID]]
-OPENROUTER_API_KEY = [[OPENROUTER_API_KEY]]
+ACTUAL_AI_OPENROUTER_API_KEY = [[ACTUAL_AI_OPENROUTER_API_KEY]]
 """
 [[stack]]
 name = "openhands"

--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -309,7 +309,7 @@ run_directory = "komodo/stacks/actual-ai"
 environment = """
 ACTUAL_AI_ACTUAL_PASSWORD = [[ACTUAL_AI_ACTUAL_PASSWORD]]
 ACTUAL_AI_BUDGET_ID = [[ACTUAL_AI_BUDGET_ID]]
-ACTUAL_AI_OPENROUTER_API_KEY = [[ACTUAL_AI_OPENROUTER_API_KEY]]
+OPENROUTER_API_KEY = [[OPENROUTER_API_KEY]]
 """
 [[stack]]
 name = "openhands"

--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -295,6 +295,22 @@ ACTUAL_OIDC_CLIENT_ID = [[ACTUAL_OIDC_CLIENT_ID]]
 ACTUAL_OIDC_CLIENT_SECRET = [[ACTUAL_OIDC_CLIENT_SECRET]]
 """
 [[stack]]
+name = "actual-ai"
+description = "AI-powered transaction categorization for Actual Budget"
+tags = ["finance", "ai"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "komodo/stacks/actual-ai"
+environment = """
+ACTUAL_AI_ACTUAL_PASSWORD = [[ACTUAL_AI_ACTUAL_PASSWORD]]
+ACTUAL_AI_BUDGET_ID = [[ACTUAL_AI_BUDGET_ID]]
+OPENROUTER_API_KEY = [[OPENROUTER_API_KEY]]
+"""
+[[stack]]
 name = "openhands"
 description = "OpenHands - AI autonomous coding agent"
 tags = ["ai", "tools"]

--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -12,7 +12,7 @@ services:
       FEATURES: '["suggestNewCategories"]'
       # LLM — OpenRouter
       LLM_PROVIDER: openai
-      OPENAI_API_KEY: ${OPENROUTER_API_KEY}
+      OPENAI_API_KEY: ${ACTUAL_AI_OPENROUTER_API_KEY}
       OPENAI_MODEL: deepseek/deepseek-v3.2
       OPENAI_BASE_URL: https://openrouter.ai/api/v1
     networks:

--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -1,0 +1,30 @@
+services:
+  actual-ai:
+    image: ghcr.io/sakowicz/actual-ai:latest
+    container_name: actual-ai
+    restart: unless-stopped
+    environment:
+      ACTUAL_SERVER_URL: https://actual.ravil.space
+      ACTUAL_PASSWORD: ${ACTUAL_AI_ACTUAL_PASSWORD}
+      ACTUAL_BUDGET_ID: ${ACTUAL_AI_BUDGET_ID}
+      CLASSIFICATION_SCHEDULE_CRON: "0 */4 * * *"
+      NODE_TLS_REJECT_UNAUTHORIZED: "0"
+      FEATURES: '["suggestNewCategories"]'
+      # LLM — OpenRouter
+      LLM_PROVIDER: openai
+      OPENAI_API_KEY: ${OPENROUTER_API_KEY}
+      OPENAI_MODEL: deepseek/deepseek-v3.2
+      OPENAI_BASE_URL: https://openrouter.ai/api/v1
+    networks:
+      - default
+      - traefik
+    labels:
+      "traefik.enable": "false"
+
+volumes: {}
+
+networks:
+  default:
+  traefik:
+    name: traefik_default
+    external: true

--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -10,11 +10,9 @@ services:
       CLASSIFICATION_SCHEDULE_CRON: "0 */4 * * *"
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       FEATURES: '["suggestNewCategories"]'
-      # LLM — OpenRouter
       LLM_PROVIDER: openai
-      OPENAI_API_KEY: ${ACTUAL_AI_OPENROUTER_API_KEY}
-      OPENAI_MODEL: deepseek/deepseek-v3.2
-      OPENAI_BASE_URL: https://openrouter.ai/api/v1
+      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
     networks:
       - default
       - traefik

--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -11,7 +11,7 @@ services:
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       FEATURES: '["suggestNewCategories"]'
       LLM_PROVIDER: openrouter
-      OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
+      OPENROUTER_API_KEY: ${ACTUAL_AI_OPENROUTER_API_KEY}
       OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
     networks:
       - default

--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -10,7 +10,7 @@ services:
       CLASSIFICATION_SCHEDULE_CRON: "0 */4 * * *"
       NODE_TLS_REJECT_UNAUTHORIZED: "0"
       FEATURES: '["suggestNewCategories"]'
-      LLM_PROVIDER: openai
+      LLM_PROVIDER: openrouter
       OPENROUTER_API_KEY: ${OPENROUTER_API_KEY}
       OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
     networks:

--- a/komodo/stacks/actual/compose.yaml
+++ b/komodo/stacks/actual/compose.yaml
@@ -6,6 +6,7 @@ services:
     volumes:
       - actual_data:/data
     environment:
+      ACTUAL_PASSWORD: ${ACTUAL_PASSWORD}
       ACTUAL_OPENID_DISCOVERY_URL: https://pocketid.ravil.space/.well-known/openid-configuration
       ACTUAL_OPENID_CLIENT_ID: ${ACTUAL_OIDC_CLIENT_ID}
       ACTUAL_OPENID_CLIENT_SECRET: ${ACTUAL_OIDC_CLIENT_SECRET}


### PR DESCRIPTION
Add actual-ai service for AI-powered transaction categorization in Actual Budget.\n\n**Features:**\n- Uses OpenRouter (deepseek/deepseek-v3.2) as LLM backend\n- Classifies transactions every 4 hours via cron schedule\n- Connects to Actual server via HTTPS API\n- No external HTTP endpoints exposed (worker only)\n\n**Required Komodo secrets:**\n- `ACTUAL_AI_ACTUAL_PASSWORD` — Actual Budget server password\n- `ACTUAL_AI_BUDGET_ID` — Budget ID to categorize\n- `OPENROUTER_API_KEY` — OpenRouter API key