### PR TITLE
fix(actual): allow password login alongside OIDC for API clients

### DIFF
--- a/komodo/stacks/actual/compose.yaml
+++ b/komodo/stacks/actual/compose.yaml
@@ -11,6 +11,7 @@ services:
       ACTUAL_OPENID_CLIENT_ID: ${ACTUAL_OIDC_CLIENT_ID}
       ACTUAL_OPENID_CLIENT_SECRET: ${ACTUAL_OIDC_CLIENT_SECRET}
       ACTUAL_OPENID_SERVER_HOSTNAME: https://actual.ravil.space
+      ACTUAL_ALLOWED_LOGIN_METHODS: password,openid
     networks:
       - default
       - traefik


### PR DESCRIPTION
## Summary

- Adds `ACTUAL_ALLOWED_LOGIN_METHODS: password,openid` to the Actual Budget server
- Fixes `actual-ai` authentication failure: as a headless service it cannot complete the OIDC browser redirect flow, so the server must allow password auth alongside OpenID

## Test plan

- [ ] Deploy updated `actual` stack via Komodo
- [ ] Confirm `actual-ai` logs no longer show "Authentication failed: Invalid redirect URL"
- [ ] Verify OIDC login still works in the Actual Budget web UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)