### PR TITLE
fix(actual-ai): set tmpfs mode 0777 to allow non-root write access

### DIFF
--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -13,6 +13,8 @@ services:
       LLM_PROVIDER: openrouter
       OPENROUTER_API_KEY: ${ACTUAL_AI_OPENROUTER_API_KEY}
       OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
+    tmpfs:
+      - /tmp/actual-ai
     networks:
       - default
       - traefik

--- a/komodo/stacks/actual-ai/compose.yaml
+++ b/komodo/stacks/actual-ai/compose.yaml
@@ -13,8 +13,11 @@ services:
       LLM_PROVIDER: openrouter
       OPENROUTER_API_KEY: ${ACTUAL_AI_OPENROUTER_API_KEY}
       OPENROUTER_BASE_URL: https://openrouter.ai/api/v1
-    tmpfs:
-      - /tmp/actual-ai
+    volumes:
+      - type: tmpfs
+        target: /tmp/actual-ai
+        tmpfs:
+          mode: 0777
     networks:
       - default
       - traefik

--- a/komodo/stacks/actual/compose.yaml
+++ b/komodo/stacks/actual/compose.yaml
@@ -11,6 +11,7 @@ services:
       ACTUAL_OPENID_CLIENT_ID: ${ACTUAL_OIDC_CLIENT_ID}
       ACTUAL_OPENID_CLIENT_SECRET: ${ACTUAL_OIDC_CLIENT_SECRET}
       ACTUAL_OPENID_SERVER_HOSTNAME: https://actual.ravil.space
+      ACTUAL_ALLOWED_LOGIN_METHODS: password,openid
     networks:
       - default
       - traefik


### PR DESCRIPTION
## Summary
- Switches tmpfs mount from short-form syntax to long-form volumes syntax
- Sets `mode: 0777` so the non-root process inside the container can write lock files to `/tmp/actual-ai`
- Fixes: `EACCES: permission denied, open '/tmp/actual-ai/.actual-ai.lock'`

## Test plan
- [ ] Deploy updated stack via Komodo
- [ ] Verify actual-ai starts without permission errors on the lock file

🤖 Generated with [Claude Code](https://claude.com/claude-code)