### PR TITLE
feat: add vova medcenter demo stack

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -262,7 +262,17 @@ repo = "ravilushqa/homelab"
 branch = "main"
 run_directory = "komodo/stacks/ntfy"
 
-
+[[stack]]
+name = "vova-medcenter"
+description = "MedCenters demo app"
+tags = ["demo", "tools"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "komodo/stacks/vova-medcenter"
 
 [[stack]]
 name = "hr-breaker"

--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -1,0 +1,50 @@
+# vova-medcenter
+
+Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medcenter).
+
+- Public URL: https://vova-medcenter.ravil.space
+- Demo UI: https://vova-medcenter.ravil.space/demo/index.html
+- Upstream commit: `220b7e785b5e66650a84f18c414ab4234beed923`
+
+## Architecture
+
+- `db`: PostgreSQL 16 for demo data.
+- `backend`: FastAPI app. Runs Alembic migrations on start, then Uvicorn on `:8000`.
+- `frontend`: nginx serving the Vite build and proxying `/api/` to `backend:8000`.
+
+The upstream repo currently ships only a local Windows/demo compose for Postgres, so this stack uses `dockerfile_inline` to keep the Komodo deployment self-contained while building directly from the pinned upstream Git commit.
+
+## Traefik
+
+The frontend is exposed through the standard Komodo Traefik setup:
+
+- router: `vova-medcenter`
+- entrypoint: `websecure`
+- cert resolver: `cloudflare`
+- Docker network: `traefik_default`
+
+No OIDC middleware is attached because this is an external demo.
+
+## First-run demo data import
+
+After first deploy, seed the demo legacy dataset:
+
+```bash
+ssh 192.168.1.166 \
+  'docker exec vova-medcenter-backend curl -sS -X POST http://127.0.0.1:8000/api/v1/imports/demo-legacy'
+```
+
+Expected response shape:
+
+```json
+{"source":"/frontend/public/demo/legacy-data.js","created":12029,"updated":2,"total":12032,"imported":12031}
+```
+
+## Verification
+
+```bash
+curl -sk -o /dev/null -w '%{http_code}\n' https://vova-medcenter.ravil.space/
+curl -sk https://vova-medcenter.ravil.space/api/v1/health
+curl -sk 'https://vova-medcenter.ravil.space/api/v1/clients?limit=1'
+ssh 192.168.1.166 'docker logs traefik --tail 200 | grep -i vova-medcenter | tail -20'
+```

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -1,0 +1,121 @@
+services:
+  db:
+    image: postgres:16
+    container_name: vova-medcenter-db
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: medcenters
+      POSTGRES_USER: medcenters
+      POSTGRES_PASSWORD: medcenters
+    volumes:
+      - vova-medcenter-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U medcenters -d medcenters"]
+      interval: 5s
+      timeout: 5s
+      retries: 30
+
+  backend:
+    build:
+      context: https://github.com/Zent7/vova-medcenter.git#220b7e785b5e66650a84f18c414ab4234beed923
+      dockerfile_inline: |
+        FROM python:3.12-slim
+
+        ENV PYTHONDONTWRITEBYTECODE=1 \
+            PYTHONUNBUFFERED=1 \
+            PIP_NO_CACHE_DIR=1
+
+        WORKDIR /app
+
+        RUN apt-get update \
+            && apt-get install -y --no-install-recommends \
+                build-essential \
+                curl \
+                unixodbc-dev \
+            && rm -rf /var/lib/apt/lists/*
+
+        COPY backend/requirements.txt /app/requirements.txt
+        RUN pip install --upgrade pip \
+            && pip install -r /app/requirements.txt
+
+        COPY backend/ /app/
+        COPY frontend/public/ /app/frontend/public/
+        COPY frontend/public/ /frontend/public/
+
+        EXPOSE 8000
+
+        CMD ["sh", "-c", "python -m alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+    container_name: vova-medcenter-backend
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DATABASE_URL: postgresql+psycopg://medcenters:medcenters@db:5432/medcenters
+      FRONTEND_ORIGIN: https://vova-medcenter.ravil.space
+      PUBLIC_FRONTEND_ORIGIN: https://vova-medcenter.ravil.space
+      GENERATED_DOCUMENTS_DIR: /app/storage/generated
+    volumes:
+      - vova-medcenter-generated:/app/storage/generated
+    labels:
+      - "traefik.enable=false"
+
+  frontend:
+    build:
+      context: https://github.com/Zent7/vova-medcenter.git#220b7e785b5e66650a84f18c414ab4234beed923
+      dockerfile_inline: |
+        FROM node:22-alpine AS build
+        WORKDIR /app
+        COPY frontend/package*.json ./
+        RUN npm ci
+        COPY frontend/ ./
+        RUN npm run build
+
+        FROM nginx:1.27-alpine
+        COPY --from=build /app/dist /usr/share/nginx/html
+        COPY <<'EOF' /etc/nginx/conf.d/default.conf
+        server {
+            listen 80;
+            server_name _;
+
+            root /usr/share/nginx/html;
+            index index.html;
+
+            location /api/ {
+                proxy_pass http://backend:8000/api/;
+                proxy_http_version 1.1;
+                proxy_set_header Host $$host;
+                proxy_set_header X-Real-IP $$remote_addr;
+                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+                proxy_set_header X-Forwarded-Proto $$scheme;
+            }
+
+            location / {
+                try_files $$uri $$uri/ /index.html;
+            }
+        }
+        EOF
+        EXPOSE 80
+    container_name: vova-medcenter-frontend
+    restart: unless-stopped
+    depends_on:
+      - backend
+    networks:
+      - default
+      - traefik
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.vova-medcenter.rule=Host(`vova-medcenter.ravil.space`)"
+      - "traefik.http.routers.vova-medcenter.entrypoints=websecure"
+      - "traefik.http.routers.vova-medcenter.tls.certresolver=cloudflare"
+      - "traefik.http.services.vova-medcenter.loadbalancer.server.port=80"
+      - "traefik.docker.network=traefik_default"
+
+volumes:
+  vova-medcenter-postgres:
+  vova-medcenter-generated:
+
+networks:
+  traefik:
+    external: true
+    name: traefik_default


### PR DESCRIPTION
## Summary
- add Komodo GitOps stack for `Zent7/vova-medcenter`
- register stack in `komodo/stacks.toml`
- expose `vova-medcenter.ravil.space` via Traefik `websecure` with `cloudflare` cert resolver
- keep deployment self-contained with inline Dockerfiles built from pinned upstream commit

## Verification
- `tomllib` parse for `komodo/stacks.toml`
- `docker compose -f komodo/stacks/vova-medcenter/compose.yaml config` on Komodo host
- deployed current demo instance from the same compose
- `curl https://vova-medcenter.ravil.space/` -> 200, TLS verify 0
- `curl https://vova-medcenter.ravil.space/demo/index.html` -> 200, TLS verify 0
- `curl https://vova-medcenter.ravil.space/api/v1/health` -> 200, TLS verify 0
- Traefik access log confirms `vova-medcenter@docker` routes 200 responses
