### PR TITLE
fix: include vova medcenter document templates

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -39,6 +39,7 @@ services:
             && pip install -r /app/requirements.txt
 
         COPY backend/ /app/
+        COPY assets/templates/ /assets/templates/
         COPY frontend/public/ /app/frontend/public/
         COPY frontend/public/ /frontend/public/
 


### PR DESCRIPTION
Adds assets/templates to the backend image so /api/v1/documents/templates can load file templates in the deployed vova-medcenter demo.