### PR TITLE
chore: delegate vova-medcenter stack merges

### DIFF
--- a/.github/workflows/vova-medcenter-delegated-merge.yml
+++ b/.github/workflows/vova-medcenter-delegated-merge.yml
@@ -1,0 +1,76 @@
+name: vova-medcenter delegated merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  scope:
+    name: vova-medcenter delegated scope
+    runs-on: ubuntu-latest
+    outputs:
+      automerge: ${{ steps.scope.outputs.automerge }}
+    steps:
+      - name: Check delegated PR scope
+        id: scope
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const trustedLogin = 'Zent7';
+            const allowedPrefix = 'komodo/stacks/vova-medcenter/';
+            const pr = context.payload.pull_request;
+
+            if (!pr) {
+              core.setFailed('This workflow must run on pull_request_target.');
+              return;
+            }
+
+            const author = pr.user.login;
+            if (author !== trustedLogin) {
+              core.info(`PR author is ${author}, not ${trustedLogin}; delegated auto-merge disabled.`);
+              core.setOutput('automerge', 'false');
+              return;
+            }
+
+            const files = await github.paginate(github.rest.pulls.listFiles, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: pr.number,
+              per_page: 100,
+            });
+
+            const changed = files.map((file) => file.filename);
+            core.info(`Changed files:\n${changed.join('\n')}`);
+
+            if (changed.length === 0) {
+              core.setFailed('PR has no changed files.');
+              return;
+            }
+
+            const outsideScope = changed.filter((filename) => !filename.startsWith(allowedPrefix));
+            if (outsideScope.length > 0) {
+              core.setFailed(
+                `Zent7 is delegated only for ${allowedPrefix}*. Outside-scope files:\n` +
+                outsideScope.map((filename) => `- ${filename}`).join('\n')
+              );
+              return;
+            }
+
+            core.notice(`Delegated scope check passed for ${trustedLogin}; auto-merge is allowed.`);
+            core.setOutput('automerge', 'true');
+
+  automerge:
+    name: vova-medcenter delegated auto-merge
+    needs: scope
+    if: needs.scope.outputs.automerge == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Enable auto-merge for delegated PR
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge "$PR_URL" --squash --delete-branch --auto


### PR DESCRIPTION
Adds a pull_request_target guard for delegated vova-medcenter updates.

Behavior:
- PRs authored by Zent7 are allowed only when every changed file is under `komodo/stacks/vova-medcenter/`.
- If scope passes, the workflow enables squash auto-merge.
- Outside-scope changes fail the required check and cannot be merged via this delegation.

After this is merged, branch protection should require the `vova-medcenter delegated scope` check and no longer require a human approval for this automation path.