### PR TITLE
Update vova-medcenter deployment to client search optimization

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `220b7e785b5e66650a84f18c414ab4234beed923`
+- Upstream commit: `60f160f79ea3a5e9b27b0fae237a72ae7452c6e2`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -17,7 +17,7 @@ services:
 
   backend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#220b7e785b5e66650a84f18c414ab4234beed923
+      context: https://github.com/Zent7/vova-medcenter.git#60f160f79ea3a5e9b27b0fae237a72ae7452c6e2
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -63,7 +63,7 @@ services:
 
   frontend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#220b7e785b5e66650a84f18c414ab4234beed923
+      context: https://github.com/Zent7/vova-medcenter.git#60f160f79ea3a5e9b27b0fae237a72ae7452c6e2
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the pinned upstream `Zent7/vova-medcenter` commit used by the Komodo stack.

This pulls in the client search optimization and the dashboard update that shows newly-created clients without requiring a manual page refresh.

Verification after deploy:
- `/demo/index.html` no longer loads `legacy-data.js`
- demo loads `app.js?v=20260601-client-search`
- `/api/v1/clients/search?limit=1` returns 200