### PR TITLE
feat: add Honcho memory stack

### DIFF
--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -263,6 +263,21 @@ branch = "main"
 run_directory = "komodo/stacks/ntfy"
 
 [[stack]]
+name = "honcho"
+description = "AI-native memory backend for Hermes"
+tags = ["ai", "tools", "memory"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
+run_directory = "komodo/stacks/honcho"
+environment = """
+GEMINI_API_KEY = [[GEMINI_API_KEY]]
+"""
+
+[[stack]]
 name = "vova-medcenter"
 description = "MedCenters demo app"
 tags = ["demo", "tools"]

--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -275,6 +275,7 @@ branch = "main"
 run_directory = "komodo/stacks/honcho"
 environment = """
 GEMINI_API_KEY = [[GEMINI_API_KEY]]
+HONCHO_DB_PASSWORD = [[HONCHO_DB_PASSWORD]]
 """
 
 [[stack]]

--- a/komodo/stacks/honcho/compose.yaml
+++ b/komodo/stacks/honcho/compose.yaml
@@ -1,0 +1,97 @@
+services:
+  api:
+    build:
+      context: https://github.com/plastic-labs/honcho.git#main
+      dockerfile: Dockerfile
+    container_name: honcho-api
+    restart: unless-stopped
+    entrypoint: ["sh", "docker/entrypoint.sh"]
+    depends_on:
+      database:
+        condition: service_healthy
+      redis:
+        condition: service_healthy
+    ports:
+      - "192.168.1.166:8077:8000"
+    environment:
+      DB_CONNECTION_URI: postgresql+psycopg://postgres:postgres@database:5432/postgres
+      CACHE_URL: redis://redis:6379/0
+      AUTH_USE_AUTH: "false"
+      LLM_GEMINI_API_KEY: ${GEMINI_API_KEY}
+      DERIVER_MODEL_CONFIG__TRANSPORT: gemini
+      DERIVER_MODEL_CONFIG__MODEL: gemini-2.5-flash
+      SUMMARY_MODEL_CONFIG__TRANSPORT: gemini
+      SUMMARY_MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DREAM_DEDUCTION_MODEL_CONFIG__TRANSPORT: gemini
+      DREAM_DEDUCTION_MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DREAM_INDUCTION_MODEL_CONFIG__TRANSPORT: gemini
+      DREAM_INDUCTION_MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__TRANSPORT: gemini
+      DIALECTIC_LEVELS__minimal__MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__TRANSPORT: gemini
+      DIALECTIC_LEVELS__low__MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__TRANSPORT: gemini
+      DIALECTIC_LEVELS__medium__MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__TRANSPORT: gemini
+      DIALECTIC_LEVELS__high__MODEL_CONFIG__MODEL: gemini-2.5-flash
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__TRANSPORT: gemini
+      DIALECTIC_LEVELS__max__MODEL_CONFIG__MODEL: gemini-2.5-flash
+      EMBEDDING_MODEL_CONFIG__TRANSPORT: gemini
+      EMBEDDING_MODEL_CONFIG__MODEL: gemini-embedding-001
+      EMBEDDING_VECTOR_DIMENSIONS: "1536"
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "/app/.venv/bin/python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8000/health', timeout=2).read()",
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 10
+      start_period: 30s
+    labels:
+      traefik.enable: "false"
+    networks:
+      - default
+
+  database:
+    image: pgvector/pgvector:pg16
+    container_name: honcho-database
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: postgres
+      POSTGRES_USER: postgres
+      POSTGRES_PASSWORD: postgres
+    volumes:
+      - honcho-postgres:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d postgres"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - default
+
+  redis:
+    image: redis:7-alpine
+    container_name: honcho-redis
+    restart: unless-stopped
+    volumes:
+      - honcho-redis:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    networks:
+      - default
+
+volumes:
+  honcho-postgres:
+  honcho-redis:
+
+networks:
+  default:
+    name: honcho

--- a/komodo/stacks/honcho/compose.yaml
+++ b/komodo/stacks/honcho/compose.yaml
@@ -1,7 +1,7 @@
 services:
   api:
     build:
-      context: https://github.com/plastic-labs/honcho.git#main
+      context: https://github.com/plastic-labs/honcho.git#9f26fdd2ea2952904fc938f69c414ca95fc59ad2
       dockerfile: Dockerfile
     container_name: honcho-api
     restart: unless-stopped
@@ -14,7 +14,7 @@ services:
     ports:
       - "192.168.1.166:8077:8000"
     environment:
-      DB_CONNECTION_URI: postgresql+psycopg://postgres:postgres@database:5432/postgres
+      DB_CONNECTION_URI: postgresql+psycopg://postgres:${HONCHO_DB_PASSWORD:?HONCHO_DB_PASSWORD is required}@database:5432/postgres
       CACHE_URL: redis://redis:6379/0
       AUTH_USE_AUTH: "false"
       LLM_GEMINI_API_KEY: ${GEMINI_API_KEY}
@@ -63,7 +63,7 @@ services:
     environment:
       POSTGRES_DB: postgres
       POSTGRES_USER: postgres
-      POSTGRES_PASSWORD: postgres
+      POSTGRES_PASSWORD: ${HONCHO_DB_PASSWORD:?HONCHO_DB_PASSWORD is required}
     volumes:
       - honcho-postgres:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary
- Add LAN-only Honcho Docker Compose stack with pgvector and Redis
- Configure Gemini LLM and embedding model environment variables
- Register Honcho in Komodo stacks.toml under Tools

## Verification
- docker compose config validated on Komodo host
- Honcho deployed on 192.168.1.166:8077 and /health returned {"status":"ok"}
- hermes memory status reports honcho available