### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `60f160f79ea3a5e9b27b0fae237a72ae7452c6e2`
+- Upstream commit: `d9f897034c736a51f43549ec314d073eb9401f1b`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -17,7 +17,7 @@ services:
 
   backend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#60f160f79ea3a5e9b27b0fae237a72ae7452c6e2
+      context: https://github.com/Zent7/vova-medcenter.git#d9f897034c736a51f43549ec314d073eb9401f1b
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -63,7 +63,7 @@ services:
 
   frontend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#60f160f79ea3a5e9b27b0fae237a72ae7452c6e2
+      context: https://github.com/Zent7/vova-medcenter.git#d9f897034c736a51f43549ec314d073eb9401f1b
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter stack to build from Zent7/vova-medcenter commit d9f897034c736a51f43549ec314d073eb9401f1b.\n\nValidation:\n- backend unittest for driver document context\n- frontend production build\n- docker compose config --quiet