### PR TITLE
fix: let delegated merges trigger deployments

### DIFF
--- a/.github/workflows/vova-medcenter-delegated-merge.yml
+++ b/.github/workflows/vova-medcenter-delegated-merge.yml
@@ -71,6 +71,9 @@ jobs:
     steps:
       - name: Enable auto-merge for delegated PR
         env:
-          GH_TOKEN: ${{ github.token }}
+          # Use a PAT instead of GITHUB_TOKEN so the resulting push to main can
+          # trigger downstream workflows, especially the push-based Komodo Deploy
+          # workflow. GitHub suppresses most workflow runs caused by GITHUB_TOKEN.
+          GH_TOKEN: ${{ secrets.PAT_TOKEN }}
           PR_URL: ${{ github.event.pull_request.html_url }}
         run: gh pr merge "$PR_URL" --squash --delete-branch --auto


### PR DESCRIPTION
## Summary
- Switch delegated vova-medcenter auto-merge from `GITHUB_TOKEN` to `secrets.PAT_TOKEN`.
- Document why: merges performed with `GITHUB_TOKEN` do not trigger the push-based Komodo Deploy workflow.
- Keep the existing trusted author and path scope checks unchanged.

## Verification
- Parsed `.github/workflows/vova-medcenter-delegated-merge.yml` with PyYAML.
- Confirmed `automerge` step now uses `${{ secrets.PAT_TOKEN }}`.

## Notes
This should make future delegated Zent7 merges produce a normal push event that can run `.github/workflows/komodo-deploy.yaml`.
