### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `d9f897034c736a51f43549ec314d073eb9401f1b`
+- Upstream commit: `860b2c3b0c936ea82b13795021e9ffc7fa5cb763`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -17,7 +17,7 @@ services:
 
   backend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#d9f897034c736a51f43549ec314d073eb9401f1b
+      context: https://github.com/Zent7/vova-medcenter.git#860b2c3b0c936ea82b13795021e9ffc7fa5cb763
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -63,7 +63,7 @@ services:
 
   frontend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#d9f897034c736a51f43549ec314d073eb9401f1b
+      context: https://github.com/Zent7/vova-medcenter.git#860b2c3b0c936ea82b13795021e9ffc7fa5cb763
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter stack to build from Zent7/vova-medcenter commit 860b2c3b0c936ea82b13795021e9ffc7fa5cb763.\n\nIncludes the local browser date display fix: Russian date format, no raw ISO dates, and no two-digit birth years.\n\nValidation:\n- frontend production build\n- docker compose config --quiet