### PR TITLE
Update vova-medcenter preset fix commit

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:9903923da518679e094538b407ab0e11040cb91f
+    image: vova-medcenter-backend:db4e3649b2944bda917ed8bd84b4757d3d76d0a0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#9903923da518679e094538b407ab0e11040cb91f
+      context: https://github.com/Zent7/vova-medcenter.git#db4e3649b2944bda917ed8bd84b4757d3d76d0a0
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:9903923da518679e094538b407ab0e11040cb91f
+    image: vova-medcenter-frontend:db4e3649b2944bda917ed8bd84b4757d3d76d0a0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#9903923da518679e094538b407ab0e11040cb91f
+      context: https://github.com/Zent7/vova-medcenter.git#db4e3649b2944bda917ed8bd84b4757d3d76d0a0
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Deploys db4e3649 with the doctor preset initial-state fix, so changing from Normal to another complaint preset updates fields while preserving manual edits.