### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -17,7 +17,7 @@ services:
 
   backend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#d9f897034c736a51f43549ec314d073eb9401f1b
+      context: https://github.com/Zent7/vova-medcenter.git#38c7f0b7da4f36ed698ae515df9e228ed9e49233
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -63,7 +63,7 @@ services:
 
   frontend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#d9f897034c736a51f43549ec314d073eb9401f1b
+      context: https://github.com/Zent7/vova-medcenter.git#38c7f0b7da4f36ed698ae515df9e228ed9e49233
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -17,7 +17,7 @@ services:
 
   backend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#38c7f0b7da4f36ed698ae515df9e228ed9e49233
+      context: https://github.com/Zent7/vova-medcenter.git#f569ec933df6c677e76d1083b07edb8b8358abf1
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -63,7 +63,7 @@ services:
 
   frontend:
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#38c7f0b7da4f36ed698ae515df9e228ed9e49233
+      context: https://github.com/Zent7/vova-medcenter.git#f569ec933df6c677e76d1083b07edb8b8358abf1
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Pins vova-medcenter backend/frontend build contexts to Zent7/vova-medcenter@38c7f0b7da4f36ed698ae515df9e228ed9e49233.

Auto-merge/deploy is left to the repository workflow.