### PR TITLE
Update vova-medcenter chairman print commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `860b2c3b0c936ea82b13795021e9ffc7fa5cb763`
+- Upstream commit: `567c0ed6537293471817e21d2305823430a2cfdd`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:f569ec933df6c677e76d1083b07edb8b8358abf1
+    image: vova-medcenter-backend:567c0ed6537293471817e21d2305823430a2cfdd
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#f569ec933df6c677e76d1083b07edb8b8358abf1
+      context: https://github.com/Zent7/vova-medcenter.git#567c0ed6537293471817e21d2305823430a2cfdd
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:f569ec933df6c677e76d1083b07edb8b8358abf1
+    image: vova-medcenter-frontend:567c0ed6537293471817e21d2305823430a2cfdd
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#f569ec933df6c677e76d1083b07edb8b8358abf1
+      context: https://github.com/Zent7/vova-medcenter.git#567c0ed6537293471817e21d2305823430a2cfdd
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 567c0ed6537293471817e21d2305823430a2cfdd, which refreshes the demo app.js cache-buster so the chairman window uses the single Print button.