### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:567c0ed6537293471817e21d2305823430a2cfdd
+    image: vova-medcenter-backend:0f9ad0523f1ccfe7b0bdc1bfeb75d49ef8031408
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#567c0ed6537293471817e21d2305823430a2cfdd
+      context: https://github.com/Zent7/vova-medcenter.git#0f9ad0523f1ccfe7b0bdc1bfeb75d49ef8031408
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:567c0ed6537293471817e21d2305823430a2cfdd
+    image: vova-medcenter-frontend:0f9ad0523f1ccfe7b0bdc1bfeb75d49ef8031408
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#567c0ed6537293471817e21d2305823430a2cfdd
+      context: https://github.com/Zent7/vova-medcenter.git#0f9ad0523f1ccfe7b0bdc1bfeb75d49ef8031408
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates only komodo/stacks/vova-medcenter/compose.yaml to build from Zent7/vova-medcenter commit 0f9ad0523f1ccfe7b0bdc1bfeb75d49ef8031408.