### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8b508112f84d754ee1642548c9cad4e0e5996cbe
+    image: vova-medcenter-backend:5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8b508112f84d754ee1642548c9cad4e0e5996cbe
+      context: https://github.com/Zent7/vova-medcenter.git#5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8b508112f84d754ee1642548c9cad4e0e5996cbe
+    image: vova-medcenter-frontend:5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8b508112f84d754ee1642548c9cad4e0e5996cbe
+      context: https://github.com/Zent7/vova-medcenter.git#5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates only komodo/stacks/vova-medcenter/compose.yaml to build from Zent7/vova-medcenter commit 5fab2f0fa8c7d9024dd96061b7ca4acb43181e45.