### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `567c0ed6537293471817e21d2305823430a2cfdd`
+- Upstream commit: `45b6c219bc0980d5a8adf114aac3dbb97e02e7ea`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
+    image: vova-medcenter-backend:45b6c219bc0980d5a8adf114aac3dbb97e02e7ea
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
+      context: https://github.com/Zent7/vova-medcenter.git#45b6c219bc0980d5a8adf114aac3dbb97e02e7ea
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
+    image: vova-medcenter-frontend:45b6c219bc0980d5a8adf114aac3dbb97e02e7ea
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5fab2f0fa8c7d9024dd96061b7ca4acb43181e45
+      context: https://github.com/Zent7/vova-medcenter.git#45b6c219bc0980d5a8adf114aac3dbb97e02e7ea
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 45b6c219bc0980d5a8adf114aac3dbb97e02e7ea.