### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `bede2eb52b43ede606c59e5ac3895897a491c59d`
+- Upstream commit: `3e21fd8cb083b45591749e6bc7d9bf05944ea92e`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:bede2eb52b43ede606c59e5ac3895897a491c59d
+    image: vova-medcenter-backend:3e21fd8cb083b45591749e6bc7d9bf05944ea92e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#bede2eb52b43ede606c59e5ac3895897a491c59d
+      context: https://github.com/Zent7/vova-medcenter.git#3e21fd8cb083b45591749e6bc7d9bf05944ea92e
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:bede2eb52b43ede606c59e5ac3895897a491c59d
+    image: vova-medcenter-frontend:3e21fd8cb083b45591749e6bc7d9bf05944ea92e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#bede2eb52b43ede606c59e5ac3895897a491c59d
+      context: https://github.com/Zent7/vova-medcenter.git#3e21fd8cb083b45591749e6bc7d9bf05944ea92e
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 3e21fd8cb083b45591749e6bc7d9bf05944ea92e.