### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `3e21fd8cb083b45591749e6bc7d9bf05944ea92e`
+- Upstream commit: `5d17df7ad5bcd37f375d45e2856769c22bb6f30f`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:3e21fd8cb083b45591749e6bc7d9bf05944ea92e
+    image: vova-medcenter-backend:5d17df7ad5bcd37f375d45e2856769c22bb6f30f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#3e21fd8cb083b45591749e6bc7d9bf05944ea92e
+      context: https://github.com/Zent7/vova-medcenter.git#5d17df7ad5bcd37f375d45e2856769c22bb6f30f
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:3e21fd8cb083b45591749e6bc7d9bf05944ea92e
+    image: vova-medcenter-frontend:5d17df7ad5bcd37f375d45e2856769c22bb6f30f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#3e21fd8cb083b45591749e6bc7d9bf05944ea92e
+      context: https://github.com/Zent7/vova-medcenter.git#5d17df7ad5bcd37f375d45e2856769c22bb6f30f
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 5d17df7ad5bcd37f375d45e2856769c22bb6f30f.