### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `29a4c811afd63e875783112d10fcb670eccd18b8`
+- Upstream commit: `809f2869aa38d833c2722ecdd7a71d9d93d78495`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:29a4c811afd63e875783112d10fcb670eccd18b8
+    image: vova-medcenter-backend:809f2869aa38d833c2722ecdd7a71d9d93d78495
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#29a4c811afd63e875783112d10fcb670eccd18b8
+      context: https://github.com/Zent7/vova-medcenter.git#809f2869aa38d833c2722ecdd7a71d9d93d78495
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:29a4c811afd63e875783112d10fcb670eccd18b8
+    image: vova-medcenter-frontend:809f2869aa38d833c2722ecdd7a71d9d93d78495
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#29a4c811afd63e875783112d10fcb670eccd18b8
+      context: https://github.com/Zent7/vova-medcenter.git#809f2869aa38d833c2722ecdd7a71d9d93d78495
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 809f2869aa38d833c2722ecdd7a71d9d93d78495.