### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `12d3266764ec20eb87398a4072c76f2380cc8ba5`
+- Upstream commit: `8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:12d3266764ec20eb87398a4072c76f2380cc8ba5
+    image: vova-medcenter-backend:8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#12d3266764ec20eb87398a4072c76f2380cc8ba5
+      context: https://github.com/Zent7/vova-medcenter.git#8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:12d3266764ec20eb87398a4072c76f2380cc8ba5
+    image: vova-medcenter-frontend:8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#12d3266764ec20eb87398a4072c76f2380cc8ba5
+      context: https://github.com/Zent7/vova-medcenter.git#8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a.