### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a`
+- Upstream commit: `996e86e4a6c86531171383154664c6b8d835e7f9`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
+    image: vova-medcenter-backend:996e86e4a6c86531171383154664c6b8d835e7f9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
+      context: https://github.com/Zent7/vova-medcenter.git#996e86e4a6c86531171383154664c6b8d835e7f9
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
+    image: vova-medcenter-frontend:996e86e4a6c86531171383154664c6b8d835e7f9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8f1b5d53ce5ee77b9526e107a59bc0a6b679a01a
+      context: https://github.com/Zent7/vova-medcenter.git#996e86e4a6c86531171383154664c6b8d835e7f9
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 996e86e4a6c86531171383154664c6b8d835e7f9.