### PR TITLE
Deploy vova medcenter direct document open

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `f7325b2bcc6f3413b5d15da97b7a116bc3f7c814`
+- Upstream commit: `db4ec800e69ce95809f21f9b3f72ad1fa9f729bd`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:f7325b2bcc6f3413b5d15da97b7a116bc3f7c814
+    image: vova-medcenter-backend:db4ec800e69ce95809f21f9b3f72ad1fa9f729bd
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#f7325b2bcc6f3413b5d15da97b7a116bc3f7c814
+      context: https://github.com/Zent7/vova-medcenter.git#db4ec800e69ce95809f21f9b3f72ad1fa9f729bd
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:f7325b2bcc6f3413b5d15da97b7a116bc3f7c814
+    image: vova-medcenter-frontend:db4ec800e69ce95809f21f9b3f72ad1fa9f729bd
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#f7325b2bcc6f3413b5d15da97b7a116bc3f7c814
+      context: https://github.com/Zent7/vova-medcenter.git#db4ec800e69ce95809f21f9b3f72ad1fa9f729bd
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Deploys Zent7/vova-medcenter@db4ec800e69ce95809f21f9b3f72ad1fa9f729bd so certificate print opens the generated Word document directly instead of using the print agent.