### PR TITLE
Deploy chairman medical print template fix

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5b58aae8db72a8c88306bd212ea99924eb7ae353`
+- Upstream commit: `015d151c93283bca23031f908cd7896a64daf4b7`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5b58aae8db72a8c88306bd212ea99924eb7ae353
+    image: vova-medcenter-backend:015d151c93283bca23031f908cd7896a64daf4b7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5b58aae8db72a8c88306bd212ea99924eb7ae353
+      context: https://github.com/Zent7/vova-medcenter.git#015d151c93283bca23031f908cd7896a64daf4b7
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5b58aae8db72a8c88306bd212ea99924eb7ae353
+    image: vova-medcenter-frontend:015d151c93283bca23031f908cd7896a64daf4b7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5b58aae8db72a8c88306bd212ea99924eb7ae353
+      context: https://github.com/Zent7/vova-medcenter.git#015d151c93283bca23031f908cd7896a64daf4b7
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Deploys Zent7/vova-medcenter@015d151c93283bca23031f908cd7896a64daf4b7 so chairman medical commission print uses the medical document template and does not leave an about:blank tab.