### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `015d151c93283bca23031f908cd7896a64daf4b7`
+- Upstream commit: `88034afe68be6eccb69d0a2c3753ca578b7353a3`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:015d151c93283bca23031f908cd7896a64daf4b7
+    image: vova-medcenter-backend:88034afe68be6eccb69d0a2c3753ca578b7353a3
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#015d151c93283bca23031f908cd7896a64daf4b7
+      context: https://github.com/Zent7/vova-medcenter.git#88034afe68be6eccb69d0a2c3753ca578b7353a3
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:015d151c93283bca23031f908cd7896a64daf4b7
+    image: vova-medcenter-frontend:88034afe68be6eccb69d0a2c3753ca578b7353a3
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#015d151c93283bca23031f908cd7896a64daf4b7
+      context: https://github.com/Zent7/vova-medcenter.git#88034afe68be6eccb69d0a2c3753ca578b7353a3
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 88034afe68be6eccb69d0a2c3753ca578b7353a3.