### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `be399d6a721ef65c537062f2c15166da5c2a84b6`
+- Upstream commit: `c511d2668305745ce47656762fe3b56ad916eb81`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:be399d6a721ef65c537062f2c15166da5c2a84b6
+    image: vova-medcenter-backend:c511d2668305745ce47656762fe3b56ad916eb81
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#be399d6a721ef65c537062f2c15166da5c2a84b6
+      context: https://github.com/Zent7/vova-medcenter.git#c511d2668305745ce47656762fe3b56ad916eb81
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:be399d6a721ef65c537062f2c15166da5c2a84b6
+    image: vova-medcenter-frontend:c511d2668305745ce47656762fe3b56ad916eb81
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#be399d6a721ef65c537062f2c15166da5c2a84b6
+      context: https://github.com/Zent7/vova-medcenter.git#c511d2668305745ce47656762fe3b56ad916eb81
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit c511d2668305745ce47656762fe3b56ad916eb81.