### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `c554c67d1a18c4300907426412a73a4c2ac0d589`
+- Upstream commit: `774c3f2bb75a259723d501e078b0b301de64c6b2`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:c554c67d1a18c4300907426412a73a4c2ac0d589
+    image: vova-medcenter-backend:774c3f2bb75a259723d501e078b0b301de64c6b2
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#c554c67d1a18c4300907426412a73a4c2ac0d589
+      context: https://github.com/Zent7/vova-medcenter.git#774c3f2bb75a259723d501e078b0b301de64c6b2
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:c554c67d1a18c4300907426412a73a4c2ac0d589
+    image: vova-medcenter-frontend:774c3f2bb75a259723d501e078b0b301de64c6b2
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#c554c67d1a18c4300907426412a73a4c2ac0d589
+      context: https://github.com/Zent7/vova-medcenter.git#774c3f2bb75a259723d501e078b0b301de64c6b2
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit d13edbb037e036303c15e4dac0d1c845b78d83ba.