### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `774c3f2bb75a259723d501e078b0b301de64c6b2`
+- Upstream commit: `bef4658039a21ae728e7adafaef86cfc6f63e7ca`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:774c3f2bb75a259723d501e078b0b301de64c6b2
+    image: vova-medcenter-backend:bef4658039a21ae728e7adafaef86cfc6f63e7ca
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#774c3f2bb75a259723d501e078b0b301de64c6b2
+      context: https://github.com/Zent7/vova-medcenter.git#bef4658039a21ae728e7adafaef86cfc6f63e7ca
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:774c3f2bb75a259723d501e078b0b301de64c6b2
+    image: vova-medcenter-frontend:bef4658039a21ae728e7adafaef86cfc6f63e7ca
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#774c3f2bb75a259723d501e078b0b301de64c6b2
+      context: https://github.com/Zent7/vova-medcenter.git#bef4658039a21ae728e7adafaef86cfc6f63e7ca
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit bef4658039a21ae728e7adafaef86cfc6f63e7ca.