### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `bef4658039a21ae728e7adafaef86cfc6f63e7ca`
+- Upstream commit: `a2d812ff1ea0cec44ccd0d27bb11f57e352e3f73`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:bef4658039a21ae728e7adafaef86cfc6f63e7ca
+    image: vova-medcenter-backend:a2d812ff1ea0cec44ccd0d27bb11f57e352e3f73
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#bef4658039a21ae728e7adafaef86cfc6f63e7ca
+      context: https://github.com/Zent7/vova-medcenter.git#a2d812ff1ea0cec44ccd0d27bb11f57e352e3f73
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:bef4658039a21ae728e7adafaef86cfc6f63e7ca
+    image: vova-medcenter-frontend:a2d812ff1ea0cec44ccd0d27bb11f57e352e3f73
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#bef4658039a21ae728e7adafaef86cfc6f63e7ca
+      context: https://github.com/Zent7/vova-medcenter.git#a2d812ff1ea0cec44ccd0d27bb11f57e352e3f73
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit a2d812ff1ea0cec44ccd0d27bb11f57e352e3f73.