### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `de61ec02545b5ccbce35cd7e04b4d7434b4f1380`
+- Upstream commit: `37800f699f6ec25407055c5a55685bae598cbe94`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:de61ec02545b5ccbce35cd7e04b4d7434b4f1380
+    image: vova-medcenter-backend:37800f699f6ec25407055c5a55685bae598cbe94
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#de61ec02545b5ccbce35cd7e04b4d7434b4f1380
+      context: https://github.com/Zent7/vova-medcenter.git#37800f699f6ec25407055c5a55685bae598cbe94
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:de61ec02545b5ccbce35cd7e04b4d7434b4f1380
+    image: vova-medcenter-frontend:37800f699f6ec25407055c5a55685bae598cbe94
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#de61ec02545b5ccbce35cd7e04b4d7434b4f1380
+      context: https://github.com/Zent7/vova-medcenter.git#37800f699f6ec25407055c5a55685bae598cbe94
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 37800f699f6ec25407055c5a55685bae598cbe94.