### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `37800f699f6ec25407055c5a55685bae598cbe94`
+- Upstream commit: `0f1a5e9f1059be74d09595a835ad7c979fbaa212`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:37800f699f6ec25407055c5a55685bae598cbe94
+    image: vova-medcenter-backend:0f1a5e9f1059be74d09595a835ad7c979fbaa212
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#37800f699f6ec25407055c5a55685bae598cbe94
+      context: https://github.com/Zent7/vova-medcenter.git#0f1a5e9f1059be74d09595a835ad7c979fbaa212
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:37800f699f6ec25407055c5a55685bae598cbe94
+    image: vova-medcenter-frontend:0f1a5e9f1059be74d09595a835ad7c979fbaa212
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#37800f699f6ec25407055c5a55685bae598cbe94
+      context: https://github.com/Zent7/vova-medcenter.git#0f1a5e9f1059be74d09595a835ad7c979fbaa212
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 0f1a5e9f1059be74d09595a835ad7c979fbaa212.