### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `9233673a7809e514be7bd4a3cd8b891455cf1783`
+- Upstream commit: `146f2366cc921774ce03e700d4ce5a4001b7bdb5`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:9233673a7809e514be7bd4a3cd8b891455cf1783
+    image: vova-medcenter-backend:146f2366cc921774ce03e700d4ce5a4001b7bdb5
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#9233673a7809e514be7bd4a3cd8b891455cf1783
+      context: https://github.com/Zent7/vova-medcenter.git#146f2366cc921774ce03e700d4ce5a4001b7bdb5
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:9233673a7809e514be7bd4a3cd8b891455cf1783
+    image: vova-medcenter-frontend:146f2366cc921774ce03e700d4ce5a4001b7bdb5
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#9233673a7809e514be7bd4a3cd8b891455cf1783
+      context: https://github.com/Zent7/vova-medcenter.git#146f2366cc921774ce03e700d4ce5a4001b7bdb5
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 146f2366cc921774ce03e700d4ce5a4001b7bdb5.