### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `51670a61d73ebe2575318cf753c0dfedd46d273f`
+- Upstream commit: `8e41ede7ed6e0fb6fa941013a08d8623ed2f34b9`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:51670a61d73ebe2575318cf753c0dfedd46d273f
+    image: vova-medcenter-backend:8e41ede7ed6e0fb6fa941013a08d8623ed2f34b9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#51670a61d73ebe2575318cf753c0dfedd46d273f
+      context: https://github.com/Zent7/vova-medcenter.git#8e41ede7ed6e0fb6fa941013a08d8623ed2f34b9
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:51670a61d73ebe2575318cf753c0dfedd46d273f
+    image: vova-medcenter-frontend:8e41ede7ed6e0fb6fa941013a08d8623ed2f34b9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#51670a61d73ebe2575318cf753c0dfedd46d273f
+      context: https://github.com/Zent7/vova-medcenter.git#8e41ede7ed6e0fb6fa941013a08d8623ed2f34b9
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 8e41ede7ed6e0fb6fa941013a08d8623ed2f34b9.