### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `b3d2177197aeb5ace3a7393d553bde60a909776d`
+- Upstream commit: `e62d60cdda48363a91ece11df6d39e8c400608a0`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:b3d2177197aeb5ace3a7393d553bde60a909776d
+    image: vova-medcenter-backend:e62d60cdda48363a91ece11df6d39e8c400608a0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b3d2177197aeb5ace3a7393d553bde60a909776d
+      context: https://github.com/Zent7/vova-medcenter.git#e62d60cdda48363a91ece11df6d39e8c400608a0
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:b3d2177197aeb5ace3a7393d553bde60a909776d
+    image: vova-medcenter-frontend:e62d60cdda48363a91ece11df6d39e8c400608a0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b3d2177197aeb5ace3a7393d553bde60a909776d
+      context: https://github.com/Zent7/vova-medcenter.git#e62d60cdda48363a91ece11df6d39e8c400608a0
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit e62d60cdda48363a91ece11df6d39e8c400608a0.