### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `90ba5c50fc12d975b7d2026b2bbfc8890323bd3a`
+- Upstream commit: `283bc014cd317c6a444816e57e41b9ca4b245431`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:90ba5c50fc12d975b7d2026b2bbfc8890323bd3a
+    image: vova-medcenter-backend:283bc014cd317c6a444816e57e41b9ca4b245431
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#90ba5c50fc12d975b7d2026b2bbfc8890323bd3a
+      context: https://github.com/Zent7/vova-medcenter.git#283bc014cd317c6a444816e57e41b9ca4b245431
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:90ba5c50fc12d975b7d2026b2bbfc8890323bd3a
+    image: vova-medcenter-frontend:283bc014cd317c6a444816e57e41b9ca4b245431
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#90ba5c50fc12d975b7d2026b2bbfc8890323bd3a
+      context: https://github.com/Zent7/vova-medcenter.git#283bc014cd317c6a444816e57e41b9ca4b245431
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 283bc014cd317c6a444816e57e41b9ca4b245431.