### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `859215822da4989da50b6b7ed9b9c8ff0307c003`
+- Upstream commit: `3e6e806b4f2011aa2ddd7d0aabdb18d73eced010`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:859215822da4989da50b6b7ed9b9c8ff0307c003
+    image: vova-medcenter-backend:3e6e806b4f2011aa2ddd7d0aabdb18d73eced010
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#859215822da4989da50b6b7ed9b9c8ff0307c003
+      context: https://github.com/Zent7/vova-medcenter.git#3e6e806b4f2011aa2ddd7d0aabdb18d73eced010
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:859215822da4989da50b6b7ed9b9c8ff0307c003
+    image: vova-medcenter-frontend:3e6e806b4f2011aa2ddd7d0aabdb18d73eced010
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#859215822da4989da50b6b7ed9b9c8ff0307c003
+      context: https://github.com/Zent7/vova-medcenter.git#3e6e806b4f2011aa2ddd7d0aabdb18d73eced010
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 3e6e806b4f2011aa2ddd7d0aabdb18d73eced010.