### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `73dae8e4f9b411a72b3e75247650ff9ac9e98ac6`
+- Upstream commit: `764e934a63232cfb6a6bb5a7d6dd30a5dd81d801`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:73dae8e4f9b411a72b3e75247650ff9ac9e98ac6
+    image: vova-medcenter-backend:764e934a63232cfb6a6bb5a7d6dd30a5dd81d801
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#73dae8e4f9b411a72b3e75247650ff9ac9e98ac6
+      context: https://github.com/Zent7/vova-medcenter.git#764e934a63232cfb6a6bb5a7d6dd30a5dd81d801
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:73dae8e4f9b411a72b3e75247650ff9ac9e98ac6
+    image: vova-medcenter-frontend:764e934a63232cfb6a6bb5a7d6dd30a5dd81d801
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#73dae8e4f9b411a72b3e75247650ff9ac9e98ac6
+      context: https://github.com/Zent7/vova-medcenter.git#764e934a63232cfb6a6bb5a7d6dd30a5dd81d801
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 764e934a63232cfb6a6bb5a7d6dd30a5dd81d801.