### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `23a03376241dc11db5e3c7ba98dd8b6c4b89f9e7`
+- Upstream commit: `13ad8028362e702387922eb4a3d9cf420fe024e7`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:23a03376241dc11db5e3c7ba98dd8b6c4b89f9e7
+    image: vova-medcenter-backend:13ad8028362e702387922eb4a3d9cf420fe024e7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#23a03376241dc11db5e3c7ba98dd8b6c4b89f9e7
+      context: https://github.com/Zent7/vova-medcenter.git#13ad8028362e702387922eb4a3d9cf420fe024e7
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:23a03376241dc11db5e3c7ba98dd8b6c4b89f9e7
+    image: vova-medcenter-frontend:13ad8028362e702387922eb4a3d9cf420fe024e7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#23a03376241dc11db5e3c7ba98dd8b6c4b89f9e7
+      context: https://github.com/Zent7/vova-medcenter.git#13ad8028362e702387922eb4a3d9cf420fe024e7
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 13ad8028362e702387922eb4a3d9cf420fe024e7.