### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `55ae2a221c089e7670a0554675e5f4ca2e91bd6b`
+- Upstream commit: `cd3cfa84fc35e9166d94c4d2516db99921190758`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:55ae2a221c089e7670a0554675e5f4ca2e91bd6b
+    image: vova-medcenter-backend:cd3cfa84fc35e9166d94c4d2516db99921190758
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#55ae2a221c089e7670a0554675e5f4ca2e91bd6b
+      context: https://github.com/Zent7/vova-medcenter.git#cd3cfa84fc35e9166d94c4d2516db99921190758
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:55ae2a221c089e7670a0554675e5f4ca2e91bd6b
+    image: vova-medcenter-frontend:cd3cfa84fc35e9166d94c4d2516db99921190758
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#55ae2a221c089e7670a0554675e5f4ca2e91bd6b
+      context: https://github.com/Zent7/vova-medcenter.git#cd3cfa84fc35e9166d94c4d2516db99921190758
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit cd3cfa84fc35e9166d94c4d2516db99921190758.