### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `71ee30ed97d3ad0105928fb9bce12492ccbf0c6b`
+- Upstream commit: `24c1664d1939151b1f49ac2a52c5a13c526fa1b9`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:71ee30ed97d3ad0105928fb9bce12492ccbf0c6b
+    image: vova-medcenter-backend:24c1664d1939151b1f49ac2a52c5a13c526fa1b9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#71ee30ed97d3ad0105928fb9bce12492ccbf0c6b
+      context: https://github.com/Zent7/vova-medcenter.git#24c1664d1939151b1f49ac2a52c5a13c526fa1b9
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:71ee30ed97d3ad0105928fb9bce12492ccbf0c6b
+    image: vova-medcenter-frontend:24c1664d1939151b1f49ac2a52c5a13c526fa1b9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#71ee30ed97d3ad0105928fb9bce12492ccbf0c6b
+      context: https://github.com/Zent7/vova-medcenter.git#24c1664d1939151b1f49ac2a52c5a13c526fa1b9
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit a1679b951ae6afee6c16717d05c4a937922bc54f.