### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `fd58d55b7580c0df9c91f6adabacfa1f60754841`
+- Upstream commit: `347cc9cf2e117532bc70c737f87377139443b542`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:fd58d55b7580c0df9c91f6adabacfa1f60754841
+    image: vova-medcenter-backend:347cc9cf2e117532bc70c737f87377139443b542
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#fd58d55b7580c0df9c91f6adabacfa1f60754841
+      context: https://github.com/Zent7/vova-medcenter.git#347cc9cf2e117532bc70c737f87377139443b542
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:fd58d55b7580c0df9c91f6adabacfa1f60754841
+    image: vova-medcenter-frontend:347cc9cf2e117532bc70c737f87377139443b542
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#fd58d55b7580c0df9c91f6adabacfa1f60754841
+      context: https://github.com/Zent7/vova-medcenter.git#347cc9cf2e117532bc70c737f87377139443b542
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit ca57644647ecbf5c7b88bbe971f56d37621dd0bc.