### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `43f6bc8e5b3aa096441087db194b8a42158f91e0`
+- Upstream commit: `2afdd037b15dbd5907104c5f9f18414cd37ba149`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:43f6bc8e5b3aa096441087db194b8a42158f91e0
+    image: vova-medcenter-backend:2afdd037b15dbd5907104c5f9f18414cd37ba149
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#43f6bc8e5b3aa096441087db194b8a42158f91e0
+      context: https://github.com/Zent7/vova-medcenter.git#2afdd037b15dbd5907104c5f9f18414cd37ba149
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:43f6bc8e5b3aa096441087db194b8a42158f91e0
+    image: vova-medcenter-frontend:2afdd037b15dbd5907104c5f9f18414cd37ba149
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#43f6bc8e5b3aa096441087db194b8a42158f91e0
+      context: https://github.com/Zent7/vova-medcenter.git#2afdd037b15dbd5907104c5f9f18414cd37ba149
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 2afdd037b15dbd5907104c5f9f18414cd37ba149.