### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `98fb5b9af3e3d917c7bdac0cc61f6312763baf2b`
+- Upstream commit: `5ad521858e8ca74fce225b548a317e8de0adb4da`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:98fb5b9af3e3d917c7bdac0cc61f6312763baf2b
+    image: vova-medcenter-backend:5ad521858e8ca74fce225b548a317e8de0adb4da
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#98fb5b9af3e3d917c7bdac0cc61f6312763baf2b
+      context: https://github.com/Zent7/vova-medcenter.git#5ad521858e8ca74fce225b548a317e8de0adb4da
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:98fb5b9af3e3d917c7bdac0cc61f6312763baf2b
+    image: vova-medcenter-frontend:5ad521858e8ca74fce225b548a317e8de0adb4da
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#98fb5b9af3e3d917c7bdac0cc61f6312763baf2b
+      context: https://github.com/Zent7/vova-medcenter.git#5ad521858e8ca74fce225b548a317e8de0adb4da
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 5ad521858e8ca74fce225b548a317e8de0adb4da.