### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `556aac4c9e4b4376ce3c67cbe14524928a8f957b`
+- Upstream commit: `1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:556aac4c9e4b4376ce3c67cbe14524928a8f957b
+    image: vova-medcenter-backend:1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#556aac4c9e4b4376ce3c67cbe14524928a8f957b
+      context: https://github.com/Zent7/vova-medcenter.git#1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:556aac4c9e4b4376ce3c67cbe14524928a8f957b
+    image: vova-medcenter-frontend:1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#556aac4c9e4b4376ce3c67cbe14524928a8f957b
+      context: https://github.com/Zent7/vova-medcenter.git#1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea.