### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea`
+- Upstream commit: `2d96412665cddf11afcebdaaa484ab8427a590bc`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
+    image: vova-medcenter-backend:2d96412665cddf11afcebdaaa484ab8427a590bc
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
+      context: https://github.com/Zent7/vova-medcenter.git#2d96412665cddf11afcebdaaa484ab8427a590bc
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
+    image: vova-medcenter-frontend:2d96412665cddf11afcebdaaa484ab8427a590bc
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1f7e6b22d37eeb9aba0ffc95a2899db0d2059dea
+      context: https://github.com/Zent7/vova-medcenter.git#2d96412665cddf11afcebdaaa484ab8427a590bc
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 2d96412665cddf11afcebdaaa484ab8427a590bc.