### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `e53371f6df4903ba275a61f735c5de4147b343ca`
+- Upstream commit: `df7c090a5e70404cf1c65649b36783450f4d6317`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e53371f6df4903ba275a61f735c5de4147b343ca
+    image: vova-medcenter-backend:df7c090a5e70404cf1c65649b36783450f4d6317
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e53371f6df4903ba275a61f735c5de4147b343ca
+      context: https://github.com/Zent7/vova-medcenter.git#df7c090a5e70404cf1c65649b36783450f4d6317
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:e53371f6df4903ba275a61f735c5de4147b343ca
+    image: vova-medcenter-frontend:df7c090a5e70404cf1c65649b36783450f4d6317
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e53371f6df4903ba275a61f735c5de4147b343ca
+      context: https://github.com/Zent7/vova-medcenter.git#df7c090a5e70404cf1c65649b36783450f4d6317
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit df7c090a5e70404cf1c65649b36783450f4d6317.