### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `df7c090a5e70404cf1c65649b36783450f4d6317`
+- Upstream commit: `8ff417c82f4c1a2c0a36c766b3567e65bebf25bf`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:df7c090a5e70404cf1c65649b36783450f4d6317
+    image: vova-medcenter-backend:8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#df7c090a5e70404cf1c65649b36783450f4d6317
+      context: https://github.com/Zent7/vova-medcenter.git#8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:df7c090a5e70404cf1c65649b36783450f4d6317
+    image: vova-medcenter-frontend:8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#df7c090a5e70404cf1c65649b36783450f4d6317
+      context: https://github.com/Zent7/vova-medcenter.git#8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 8ff417c82f4c1a2c0a36c766b3567e65bebf25bf.