### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8ff417c82f4c1a2c0a36c766b3567e65bebf25bf`
+- Upstream commit: `cc48bf64103d839865af2f464dd73b6863a0f386`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
+    image: vova-medcenter-backend:cc48bf64103d839865af2f464dd73b6863a0f386
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
+      context: https://github.com/Zent7/vova-medcenter.git#cc48bf64103d839865af2f464dd73b6863a0f386
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
+    image: vova-medcenter-frontend:cc48bf64103d839865af2f464dd73b6863a0f386
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8ff417c82f4c1a2c0a36c766b3567e65bebf25bf
+      context: https://github.com/Zent7/vova-medcenter.git#cc48bf64103d839865af2f464dd73b6863a0f386
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit cc48bf64103d839865af2f464dd73b6863a0f386.