### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `cc48bf64103d839865af2f464dd73b6863a0f386`
+- Upstream commit: `52b39cc8fcf996b2136753677a60a626424324bb`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:cc48bf64103d839865af2f464dd73b6863a0f386
+    image: vova-medcenter-backend:52b39cc8fcf996b2136753677a60a626424324bb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#cc48bf64103d839865af2f464dd73b6863a0f386
+      context: https://github.com/Zent7/vova-medcenter.git#52b39cc8fcf996b2136753677a60a626424324bb
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:cc48bf64103d839865af2f464dd73b6863a0f386
+    image: vova-medcenter-frontend:52b39cc8fcf996b2136753677a60a626424324bb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#cc48bf64103d839865af2f464dd73b6863a0f386
+      context: https://github.com/Zent7/vova-medcenter.git#52b39cc8fcf996b2136753677a60a626424324bb
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 52b39cc8fcf996b2136753677a60a626424324bb.