### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `52b39cc8fcf996b2136753677a60a626424324bb`
+- Upstream commit: `daa9ece4fe184d994588bb51e8778a25bcd811f7`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:52b39cc8fcf996b2136753677a60a626424324bb
+    image: vova-medcenter-backend:daa9ece4fe184d994588bb51e8778a25bcd811f7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#52b39cc8fcf996b2136753677a60a626424324bb
+      context: https://github.com/Zent7/vova-medcenter.git#daa9ece4fe184d994588bb51e8778a25bcd811f7
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:52b39cc8fcf996b2136753677a60a626424324bb
+    image: vova-medcenter-frontend:daa9ece4fe184d994588bb51e8778a25bcd811f7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#52b39cc8fcf996b2136753677a60a626424324bb
+      context: https://github.com/Zent7/vova-medcenter.git#daa9ece4fe184d994588bb51e8778a25bcd811f7
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit daa9ece4fe184d994588bb51e8778a25bcd811f7.