### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `9ecc75c2332a639c8c383ab2f73d6ad0cae7dec3`
+- Upstream commit: `05d4539e6e0a3f139b36802f754d38102b129cd9`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:9ecc75c2332a639c8c383ab2f73d6ad0cae7dec3
+    image: vova-medcenter-backend:05d4539e6e0a3f139b36802f754d38102b129cd9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#9ecc75c2332a639c8c383ab2f73d6ad0cae7dec3
+      context: https://github.com/Zent7/vova-medcenter.git#05d4539e6e0a3f139b36802f754d38102b129cd9
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:9ecc75c2332a639c8c383ab2f73d6ad0cae7dec3
+    image: vova-medcenter-frontend:05d4539e6e0a3f139b36802f754d38102b129cd9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#9ecc75c2332a639c8c383ab2f73d6ad0cae7dec3
+      context: https://github.com/Zent7/vova-medcenter.git#05d4539e6e0a3f139b36802f754d38102b129cd9
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter@05d4539e6e0a3f139b36802f754d38102b129cd9.