### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `05d4539e6e0a3f139b36802f754d38102b129cd9`
+- Upstream commit: `5579a7f21cfc4f68add456c026e4645a9048aa5e`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:05d4539e6e0a3f139b36802f754d38102b129cd9
+    image: vova-medcenter-backend:5579a7f21cfc4f68add456c026e4645a9048aa5e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#05d4539e6e0a3f139b36802f754d38102b129cd9
+      context: https://github.com/Zent7/vova-medcenter.git#5579a7f21cfc4f68add456c026e4645a9048aa5e
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:05d4539e6e0a3f139b36802f754d38102b129cd9
+    image: vova-medcenter-frontend:5579a7f21cfc4f68add456c026e4645a9048aa5e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#05d4539e6e0a3f139b36802f754d38102b129cd9
+      context: https://github.com/Zent7/vova-medcenter.git#5579a7f21cfc4f68add456c026e4645a9048aa5e
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter@5579a7f21cfc4f68add456c026e4645a9048aa5e.