### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5579a7f21cfc4f68add456c026e4645a9048aa5e`
+- Upstream commit: `00ad56cec1a58ed532af27ef471eecb7bc7c4d92`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5579a7f21cfc4f68add456c026e4645a9048aa5e
+    image: vova-medcenter-backend:00ad56cec1a58ed532af27ef471eecb7bc7c4d92
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5579a7f21cfc4f68add456c026e4645a9048aa5e
+      context: https://github.com/Zent7/vova-medcenter.git#00ad56cec1a58ed532af27ef471eecb7bc7c4d92
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5579a7f21cfc4f68add456c026e4645a9048aa5e
+    image: vova-medcenter-frontend:00ad56cec1a58ed532af27ef471eecb7bc7c4d92
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5579a7f21cfc4f68add456c026e4645a9048aa5e
+      context: https://github.com/Zent7/vova-medcenter.git#00ad56cec1a58ed532af27ef471eecb7bc7c4d92
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter@00ad56cec1a58ed532af27ef471eecb7bc7c4d92.