### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `00ad56cec1a58ed532af27ef471eecb7bc7c4d92`
+- Upstream commit: `ec2d321eb87d3fd50bf6cb71658edf38204f85a9`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:00ad56cec1a58ed532af27ef471eecb7bc7c4d92
+    image: vova-medcenter-backend:ec2d321eb87d3fd50bf6cb71658edf38204f85a9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#00ad56cec1a58ed532af27ef471eecb7bc7c4d92
+      context: https://github.com/Zent7/vova-medcenter.git#ec2d321eb87d3fd50bf6cb71658edf38204f85a9
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:00ad56cec1a58ed532af27ef471eecb7bc7c4d92
+    image: vova-medcenter-frontend:ec2d321eb87d3fd50bf6cb71658edf38204f85a9
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#00ad56cec1a58ed532af27ef471eecb7bc7c4d92
+      context: https://github.com/Zent7/vova-medcenter.git#ec2d321eb87d3fd50bf6cb71658edf38204f85a9
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter@ec2d321eb87d3fd50bf6cb71658edf38204f85a9.