### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `ec2d321eb87d3fd50bf6cb71658edf38204f85a9`
+- Upstream commit: `5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:ec2d321eb87d3fd50bf6cb71658edf38204f85a9
+    image: vova-medcenter-backend:5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ec2d321eb87d3fd50bf6cb71658edf38204f85a9
+      context: https://github.com/Zent7/vova-medcenter.git#5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:ec2d321eb87d3fd50bf6cb71658edf38204f85a9
+    image: vova-medcenter-frontend:5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ec2d321eb87d3fd50bf6cb71658edf38204f85a9
+      context: https://github.com/Zent7/vova-medcenter.git#5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter@5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea.