### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea`
+- Upstream commit: `47998381990498062e61e0f7faeec51bf603eaa6`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
+    image: vova-medcenter-backend:47998381990498062e61e0f7faeec51bf603eaa6
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
+      context: https://github.com/Zent7/vova-medcenter.git#47998381990498062e61e0f7faeec51bf603eaa6
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
+    image: vova-medcenter-frontend:47998381990498062e61e0f7faeec51bf603eaa6
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5b4880a3c3cca3e6e89896b4dcbceba94fbd38ea
+      context: https://github.com/Zent7/vova-medcenter.git#47998381990498062e61e0f7faeec51bf603eaa6
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 47998381990498062e61e0f7faeec51bf603eaa6.