### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5eea251b4925db07030ce76141420704685a768b`
+- Upstream commit: `1a849134bee5e872cc5c6687f47bac1241b90a55`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5eea251b4925db07030ce76141420704685a768b
+    image: vova-medcenter-backend:1a849134bee5e872cc5c6687f47bac1241b90a55
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5eea251b4925db07030ce76141420704685a768b
+      context: https://github.com/Zent7/vova-medcenter.git#1a849134bee5e872cc5c6687f47bac1241b90a55
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5eea251b4925db07030ce76141420704685a768b
+    image: vova-medcenter-frontend:1a849134bee5e872cc5c6687f47bac1241b90a55
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5eea251b4925db07030ce76141420704685a768b
+      context: https://github.com/Zent7/vova-medcenter.git#1a849134bee5e872cc5c6687f47bac1241b90a55
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 1a849134bee5e872cc5c6687f47bac1241b90a55.