### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `be7fe16f10cd1df29ddbd8d6f2d1818fcf1ae899`
+- Upstream commit: `bfacd25c993f213c2e1b69f6d2c71fe94682b518`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:be7fe16f10cd1df29ddbd8d6f2d1818fcf1ae899
+    image: vova-medcenter-backend:bfacd25c993f213c2e1b69f6d2c71fe94682b518
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#be7fe16f10cd1df29ddbd8d6f2d1818fcf1ae899
+      context: https://github.com/Zent7/vova-medcenter.git#bfacd25c993f213c2e1b69f6d2c71fe94682b518
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:be7fe16f10cd1df29ddbd8d6f2d1818fcf1ae899
+    image: vova-medcenter-frontend:bfacd25c993f213c2e1b69f6d2c71fe94682b518
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#be7fe16f10cd1df29ddbd8d6f2d1818fcf1ae899
+      context: https://github.com/Zent7/vova-medcenter.git#bfacd25c993f213c2e1b69f6d2c71fe94682b518
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit bfacd25c993f213c2e1b69f6d2c71fe94682b518.