### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `bfacd25c993f213c2e1b69f6d2c71fe94682b518`
+- Upstream commit: `b7b70bb90e4dcb637bd994f262a80069409ad623`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:bfacd25c993f213c2e1b69f6d2c71fe94682b518
+    image: vova-medcenter-backend:b7b70bb90e4dcb637bd994f262a80069409ad623
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#bfacd25c993f213c2e1b69f6d2c71fe94682b518
+      context: https://github.com/Zent7/vova-medcenter.git#b7b70bb90e4dcb637bd994f262a80069409ad623
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:bfacd25c993f213c2e1b69f6d2c71fe94682b518
+    image: vova-medcenter-frontend:b7b70bb90e4dcb637bd994f262a80069409ad623
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#bfacd25c993f213c2e1b69f6d2c71fe94682b518
+      context: https://github.com/Zent7/vova-medcenter.git#b7b70bb90e4dcb637bd994f262a80069409ad623
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit b7b70bb90e4dcb637bd994f262a80069409ad623.