### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `b7b70bb90e4dcb637bd994f262a80069409ad623`
+- Upstream commit: `7cbb589176c2580dfacaab462432ed0e6246f1cb`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:b7b70bb90e4dcb637bd994f262a80069409ad623
+    image: vova-medcenter-backend:7cbb589176c2580dfacaab462432ed0e6246f1cb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b7b70bb90e4dcb637bd994f262a80069409ad623
+      context: https://github.com/Zent7/vova-medcenter.git#7cbb589176c2580dfacaab462432ed0e6246f1cb
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:b7b70bb90e4dcb637bd994f262a80069409ad623
+    image: vova-medcenter-frontend:7cbb589176c2580dfacaab462432ed0e6246f1cb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b7b70bb90e4dcb637bd994f262a80069409ad623
+      context: https://github.com/Zent7/vova-medcenter.git#7cbb589176c2580dfacaab462432ed0e6246f1cb
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 7cbb589176c2580dfacaab462432ed0e6246f1cb.