### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `755384c9a29cbb18210301177c689b838fc1d803`
+- Upstream commit: `5b6dd30bc9f1e27c578840688b9828b82287674c`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:755384c9a29cbb18210301177c689b838fc1d803
+    image: vova-medcenter-backend:5b6dd30bc9f1e27c578840688b9828b82287674c
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#755384c9a29cbb18210301177c689b838fc1d803
+      context: https://github.com/Zent7/vova-medcenter.git#5b6dd30bc9f1e27c578840688b9828b82287674c
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:755384c9a29cbb18210301177c689b838fc1d803
+    image: vova-medcenter-frontend:5b6dd30bc9f1e27c578840688b9828b82287674c
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#755384c9a29cbb18210301177c689b838fc1d803
+      context: https://github.com/Zent7/vova-medcenter.git#5b6dd30bc9f1e27c578840688b9828b82287674c
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 27cb57b96987ae74130a1b008526c8b02f88df33.