### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `7cbb589176c2580dfacaab462432ed0e6246f1cb`
+- Upstream commit: `5c2d863b462cd5ab47a2860a695121a060b59f06`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:7cbb589176c2580dfacaab462432ed0e6246f1cb
+    image: vova-medcenter-backend:5c2d863b462cd5ab47a2860a695121a060b59f06
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#7cbb589176c2580dfacaab462432ed0e6246f1cb
+      context: https://github.com/Zent7/vova-medcenter.git#5c2d863b462cd5ab47a2860a695121a060b59f06
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:7cbb589176c2580dfacaab462432ed0e6246f1cb
+    image: vova-medcenter-frontend:5c2d863b462cd5ab47a2860a695121a060b59f06
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#7cbb589176c2580dfacaab462432ed0e6246f1cb
+      context: https://github.com/Zent7/vova-medcenter.git#5c2d863b462cd5ab47a2860a695121a060b59f06
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 5c2d863b462cd5ab47a2860a695121a060b59f06.