### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `6b1beaa5df8d9e04c429a8778af900df7394660d`
+- Upstream commit: `c6a234df1aff182507c95eab60b9d1d6fc4aa811`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:6b1beaa5df8d9e04c429a8778af900df7394660d
+    image: vova-medcenter-backend:c6a234df1aff182507c95eab60b9d1d6fc4aa811
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6b1beaa5df8d9e04c429a8778af900df7394660d
+      context: https://github.com/Zent7/vova-medcenter.git#c6a234df1aff182507c95eab60b9d1d6fc4aa811
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:6b1beaa5df8d9e04c429a8778af900df7394660d
+    image: vova-medcenter-frontend:c6a234df1aff182507c95eab60b9d1d6fc4aa811
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6b1beaa5df8d9e04c429a8778af900df7394660d
+      context: https://github.com/Zent7/vova-medcenter.git#c6a234df1aff182507c95eab60b9d1d6fc4aa811
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit c6a234df1aff182507c95eab60b9d1d6fc4aa811.