### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `c35268a47a9a3adba41d6b205d2f7bc2a9e51887`
+- Upstream commit: `0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:c35268a47a9a3adba41d6b205d2f7bc2a9e51887
+    image: vova-medcenter-backend:0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#c35268a47a9a3adba41d6b205d2f7bc2a9e51887
+      context: https://github.com/Zent7/vova-medcenter.git#0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:c35268a47a9a3adba41d6b205d2f7bc2a9e51887
+    image: vova-medcenter-frontend:0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#c35268a47a9a3adba41d6b205d2f7bc2a9e51887
+      context: https://github.com/Zent7/vova-medcenter.git#0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799.