### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799`
+- Upstream commit: `80dd3b8c7cbfdc1844fd186821ab192e0c5ac7b5`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
+    image: vova-medcenter-backend:80dd3b8c7cbfdc1844fd186821ab192e0c5ac7b5
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
+      context: https://github.com/Zent7/vova-medcenter.git#80dd3b8c7cbfdc1844fd186821ab192e0c5ac7b5
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
+    image: vova-medcenter-frontend:80dd3b8c7cbfdc1844fd186821ab192e0c5ac7b5
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#0ebbf8c4f6ea6c9eb6604ac93e339a50a3315799
+      context: https://github.com/Zent7/vova-medcenter.git#80dd3b8c7cbfdc1844fd186821ab192e0c5ac7b5
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 80dd3b8c7cbfdc1844fd186821ab192e0c5ac7b5.