### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `ef2dc5f6b5c35007e3ca5f3c35304f63a36a20d8`
+- Upstream commit: `01945141f92df7e291ac275583af7ac9afb23205`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:ef2dc5f6b5c35007e3ca5f3c35304f63a36a20d8
+    image: vova-medcenter-backend:01945141f92df7e291ac275583af7ac9afb23205
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ef2dc5f6b5c35007e3ca5f3c35304f63a36a20d8
+      context: https://github.com/Zent7/vova-medcenter.git#01945141f92df7e291ac275583af7ac9afb23205
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:ef2dc5f6b5c35007e3ca5f3c35304f63a36a20d8
+    image: vova-medcenter-frontend:01945141f92df7e291ac275583af7ac9afb23205
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ef2dc5f6b5c35007e3ca5f3c35304f63a36a20d8
+      context: https://github.com/Zent7/vova-medcenter.git#01945141f92df7e291ac275583af7ac9afb23205
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 01945141f92df7e291ac275583af7ac9afb23205.