### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8cb6c4d64974ce05e08171e824cace8b88a1d3c6`
+- Upstream commit: `6ca2c45d8304a777a19d36a882b676ff74956e00`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8cb6c4d64974ce05e08171e824cace8b88a1d3c6
+    image: vova-medcenter-backend:6ca2c45d8304a777a19d36a882b676ff74956e00
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8cb6c4d64974ce05e08171e824cace8b88a1d3c6
+      context: https://github.com/Zent7/vova-medcenter.git#6ca2c45d8304a777a19d36a882b676ff74956e00
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8cb6c4d64974ce05e08171e824cace8b88a1d3c6
+    image: vova-medcenter-frontend:6ca2c45d8304a777a19d36a882b676ff74956e00
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8cb6c4d64974ce05e08171e824cace8b88a1d3c6
+      context: https://github.com/Zent7/vova-medcenter.git#6ca2c45d8304a777a19d36a882b676ff74956e00
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 6ca2c45d8304a777a19d36a882b676ff74956e00.