### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `6ca2c45d8304a777a19d36a882b676ff74956e00`
+- Upstream commit: `776570f3f7c367e6b45aa1ef44a3d790dc44a610`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:6ca2c45d8304a777a19d36a882b676ff74956e00
+    image: vova-medcenter-backend:776570f3f7c367e6b45aa1ef44a3d790dc44a610
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6ca2c45d8304a777a19d36a882b676ff74956e00
+      context: https://github.com/Zent7/vova-medcenter.git#776570f3f7c367e6b45aa1ef44a3d790dc44a610
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:6ca2c45d8304a777a19d36a882b676ff74956e00
+    image: vova-medcenter-frontend:776570f3f7c367e6b45aa1ef44a3d790dc44a610
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6ca2c45d8304a777a19d36a882b676ff74956e00
+      context: https://github.com/Zent7/vova-medcenter.git#776570f3f7c367e6b45aa1ef44a3d790dc44a610
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 776570f3f7c367e6b45aa1ef44a3d790dc44a610.