### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `75af6b1974c1039daf5ff757f55624d0fa4bf4f1`
+- Upstream commit: `1c5b7077fd1183f4d6063b3644114210cd89bce0`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:75af6b1974c1039daf5ff757f55624d0fa4bf4f1
+    image: vova-medcenter-backend:1c5b7077fd1183f4d6063b3644114210cd89bce0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#75af6b1974c1039daf5ff757f55624d0fa4bf4f1
+      context: https://github.com/Zent7/vova-medcenter.git#1c5b7077fd1183f4d6063b3644114210cd89bce0
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:75af6b1974c1039daf5ff757f55624d0fa4bf4f1
+    image: vova-medcenter-frontend:1c5b7077fd1183f4d6063b3644114210cd89bce0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#75af6b1974c1039daf5ff757f55624d0fa4bf4f1
+      context: https://github.com/Zent7/vova-medcenter.git#1c5b7077fd1183f4d6063b3644114210cd89bce0
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 1c5b7077fd1183f4d6063b3644114210cd89bce0.