### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `1c5b7077fd1183f4d6063b3644114210cd89bce0`
+- Upstream commit: `cf243e99e53058f0303cbf76e02ed8b2e21ee393`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:1c5b7077fd1183f4d6063b3644114210cd89bce0
+    image: vova-medcenter-backend:cf243e99e53058f0303cbf76e02ed8b2e21ee393
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1c5b7077fd1183f4d6063b3644114210cd89bce0
+      context: https://github.com/Zent7/vova-medcenter.git#cf243e99e53058f0303cbf76e02ed8b2e21ee393
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:1c5b7077fd1183f4d6063b3644114210cd89bce0
+    image: vova-medcenter-frontend:cf243e99e53058f0303cbf76e02ed8b2e21ee393
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1c5b7077fd1183f4d6063b3644114210cd89bce0
+      context: https://github.com/Zent7/vova-medcenter.git#cf243e99e53058f0303cbf76e02ed8b2e21ee393
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit cf243e99e53058f0303cbf76e02ed8b2e21ee393.