### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `cf243e99e53058f0303cbf76e02ed8b2e21ee393`
+- Upstream commit: `8876c488149a294f935201a496afc11344d88171`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:cf243e99e53058f0303cbf76e02ed8b2e21ee393
+    image: vova-medcenter-backend:8876c488149a294f935201a496afc11344d88171
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#cf243e99e53058f0303cbf76e02ed8b2e21ee393
+      context: https://github.com/Zent7/vova-medcenter.git#8876c488149a294f935201a496afc11344d88171
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:cf243e99e53058f0303cbf76e02ed8b2e21ee393
+    image: vova-medcenter-frontend:8876c488149a294f935201a496afc11344d88171
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#cf243e99e53058f0303cbf76e02ed8b2e21ee393
+      context: https://github.com/Zent7/vova-medcenter.git#8876c488149a294f935201a496afc11344d88171
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 8876c488149a294f935201a496afc11344d88171.