### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8876c488149a294f935201a496afc11344d88171`
+- Upstream commit: `53e854ab8e83cfdf5607d2f4b7423417e6ca33e1`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8876c488149a294f935201a496afc11344d88171
+    image: vova-medcenter-backend:53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8876c488149a294f935201a496afc11344d88171
+      context: https://github.com/Zent7/vova-medcenter.git#53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8876c488149a294f935201a496afc11344d88171
+    image: vova-medcenter-frontend:53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8876c488149a294f935201a496afc11344d88171
+      context: https://github.com/Zent7/vova-medcenter.git#53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 53e854ab8e83cfdf5607d2f4b7423417e6ca33e1.