### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `53e854ab8e83cfdf5607d2f4b7423417e6ca33e1`
+- Upstream commit: `63fd0aff179641b33b860b6500157e84de59939c`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
+    image: vova-medcenter-backend:63fd0aff179641b33b860b6500157e84de59939c
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
+      context: https://github.com/Zent7/vova-medcenter.git#63fd0aff179641b33b860b6500157e84de59939c
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
+    image: vova-medcenter-frontend:63fd0aff179641b33b860b6500157e84de59939c
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#53e854ab8e83cfdf5607d2f4b7423417e6ca33e1
+      context: https://github.com/Zent7/vova-medcenter.git#63fd0aff179641b33b860b6500157e84de59939c
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 63fd0aff179641b33b860b6500157e84de59939c.