### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `ad0f7ac209ad8ac30f76c67909803c84254648dd`
+- Upstream commit: `24bb14f052fe1c8087b3e0c90d180f351e3127dc`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:ad0f7ac209ad8ac30f76c67909803c84254648dd
+    image: vova-medcenter-backend:24bb14f052fe1c8087b3e0c90d180f351e3127dc
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ad0f7ac209ad8ac30f76c67909803c84254648dd
+      context: https://github.com/Zent7/vova-medcenter.git#24bb14f052fe1c8087b3e0c90d180f351e3127dc
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:ad0f7ac209ad8ac30f76c67909803c84254648dd
+    image: vova-medcenter-frontend:24bb14f052fe1c8087b3e0c90d180f351e3127dc
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ad0f7ac209ad8ac30f76c67909803c84254648dd
+      context: https://github.com/Zent7/vova-medcenter.git#24bb14f052fe1c8087b3e0c90d180f351e3127dc
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 24bb14f052fe1c8087b3e0c90d180f351e3127dc.