### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `e20cb8d97691e9efaaf13a796009764a4ccea5fe`
+- Upstream commit: `914b4d08cc73358c79c56d66f8162df94d8cb58d`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e20cb8d97691e9efaaf13a796009764a4ccea5fe
+    image: vova-medcenter-backend:914b4d08cc73358c79c56d66f8162df94d8cb58d
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e20cb8d97691e9efaaf13a796009764a4ccea5fe
+      context: https://github.com/Zent7/vova-medcenter.git#914b4d08cc73358c79c56d66f8162df94d8cb58d
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:e20cb8d97691e9efaaf13a796009764a4ccea5fe
+    image: vova-medcenter-frontend:914b4d08cc73358c79c56d66f8162df94d8cb58d
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e20cb8d97691e9efaaf13a796009764a4ccea5fe
+      context: https://github.com/Zent7/vova-medcenter.git#914b4d08cc73358c79c56d66f8162df94d8cb58d
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit a513da5216366ef883d5bf9943ee7d1ce44e3661.