### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `a3531669f6173ba0a4cd473ddaac6e6ae51f2182`
+- Upstream commit: `f21271e3d4db064e8cc4d96e7fbb96f0825be8bc`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:a3531669f6173ba0a4cd473ddaac6e6ae51f2182
+    image: vova-medcenter-backend:f21271e3d4db064e8cc4d96e7fbb96f0825be8bc
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#a3531669f6173ba0a4cd473ddaac6e6ae51f2182
+      context: https://github.com/Zent7/vova-medcenter.git#f21271e3d4db064e8cc4d96e7fbb96f0825be8bc
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:a3531669f6173ba0a4cd473ddaac6e6ae51f2182
+    image: vova-medcenter-frontend:f21271e3d4db064e8cc4d96e7fbb96f0825be8bc
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#a3531669f6173ba0a4cd473ddaac6e6ae51f2182
+      context: https://github.com/Zent7/vova-medcenter.git#f21271e3d4db064e8cc4d96e7fbb96f0825be8bc
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit f21271e3d4db064e8cc4d96e7fbb96f0825be8bc.