### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `1a3b7e0177a7ca16bd28aa7853a441670f0622a3`
+- Upstream commit: `2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:1a3b7e0177a7ca16bd28aa7853a441670f0622a3
+    image: vova-medcenter-backend:2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1a3b7e0177a7ca16bd28aa7853a441670f0622a3
+      context: https://github.com/Zent7/vova-medcenter.git#2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:1a3b7e0177a7ca16bd28aa7853a441670f0622a3
+    image: vova-medcenter-frontend:2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1a3b7e0177a7ca16bd28aa7853a441670f0622a3
+      context: https://github.com/Zent7/vova-medcenter.git#2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd.