### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd`
+- Upstream commit: `d78d74ccb088145109eeae61b53ffe3f191f730e`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
+    image: vova-medcenter-backend:d78d74ccb088145109eeae61b53ffe3f191f730e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
+      context: https://github.com/Zent7/vova-medcenter.git#d78d74ccb088145109eeae61b53ffe3f191f730e
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
+    image: vova-medcenter-frontend:d78d74ccb088145109eeae61b53ffe3f191f730e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#2bbef0b0a3d50e97d69218f98ef9b72ed49bc5cd
+      context: https://github.com/Zent7/vova-medcenter.git#d78d74ccb088145109eeae61b53ffe3f191f730e
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit d78d74ccb088145109eeae61b53ffe3f191f730e.