### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5e0e021f3cdbea930b5314db2a34c64624b2aba0`
+- Upstream commit: `953831d72ca15d1627731d722e9f0809bd62c3e4`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5e0e021f3cdbea930b5314db2a34c64624b2aba0
+    image: vova-medcenter-backend:953831d72ca15d1627731d722e9f0809bd62c3e4
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5e0e021f3cdbea930b5314db2a34c64624b2aba0
+      context: https://github.com/Zent7/vova-medcenter.git#953831d72ca15d1627731d722e9f0809bd62c3e4
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5e0e021f3cdbea930b5314db2a34c64624b2aba0
+    image: vova-medcenter-frontend:953831d72ca15d1627731d722e9f0809bd62c3e4
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5e0e021f3cdbea930b5314db2a34c64624b2aba0
+      context: https://github.com/Zent7/vova-medcenter.git#953831d72ca15d1627731d722e9f0809bd62c3e4
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 953831d72ca15d1627731d722e9f0809bd62c3e4.