### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `953831d72ca15d1627731d722e9f0809bd62c3e4`
+- Upstream commit: `4f82aa35bcb878898b9a227169424fe8baa664d7`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:953831d72ca15d1627731d722e9f0809bd62c3e4
+    image: vova-medcenter-backend:4f82aa35bcb878898b9a227169424fe8baa664d7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#953831d72ca15d1627731d722e9f0809bd62c3e4
+      context: https://github.com/Zent7/vova-medcenter.git#4f82aa35bcb878898b9a227169424fe8baa664d7
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:953831d72ca15d1627731d722e9f0809bd62c3e4
+    image: vova-medcenter-frontend:4f82aa35bcb878898b9a227169424fe8baa664d7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#953831d72ca15d1627731d722e9f0809bd62c3e4
+      context: https://github.com/Zent7/vova-medcenter.git#4f82aa35bcb878898b9a227169424fe8baa664d7
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 4f82aa35bcb878898b9a227169424fe8baa664d7.