### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `4f82aa35bcb878898b9a227169424fe8baa664d7`
+- Upstream commit: `4e291e148cfd064cfe9cdae2b98e6923309ccce2`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:4f82aa35bcb878898b9a227169424fe8baa664d7
+    image: vova-medcenter-backend:4e291e148cfd064cfe9cdae2b98e6923309ccce2
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#4f82aa35bcb878898b9a227169424fe8baa664d7
+      context: https://github.com/Zent7/vova-medcenter.git#4e291e148cfd064cfe9cdae2b98e6923309ccce2
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:4f82aa35bcb878898b9a227169424fe8baa664d7
+    image: vova-medcenter-frontend:4e291e148cfd064cfe9cdae2b98e6923309ccce2
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#4f82aa35bcb878898b9a227169424fe8baa664d7
+      context: https://github.com/Zent7/vova-medcenter.git#4e291e148cfd064cfe9cdae2b98e6923309ccce2
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 4e291e148cfd064cfe9cdae2b98e6923309ccce2.