### PR TITLE
Deploy vova-medcenter guard service id fix

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `4e291e148cfd064cfe9cdae2b98e6923309ccce2`
+- Upstream commit: `aa9fbc15e6e7152034e609d6a7562d28dc45af2f`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:4e291e148cfd064cfe9cdae2b98e6923309ccce2
+    image: vova-medcenter-backend:aa9fbc15e6e7152034e609d6a7562d28dc45af2f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#4e291e148cfd064cfe9cdae2b98e6923309ccce2
+      context: https://github.com/Zent7/vova-medcenter.git#aa9fbc15e6e7152034e609d6a7562d28dc45af2f
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:4e291e148cfd064cfe9cdae2b98e6923309ccce2
+    image: vova-medcenter-frontend:aa9fbc15e6e7152034e609d6a7562d28dc45af2f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#4e291e148cfd064cfe9cdae2b98e6923309ccce2
+      context: https://github.com/Zent7/vova-medcenter.git#aa9fbc15e6e7152034e609d6a7562d28dc45af2f
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter deployment to Zent7/vova-medcenter@aa9fbc15e6e7152034e609d6a7562d28dc45af2f.\n\nIncludes guard certificate service id collision fix so 002/??? no longer saves as 071? and existing affected encounters are backfilled on startup.