### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `aa9fbc15e6e7152034e609d6a7562d28dc45af2f`
+- Upstream commit: `87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:aa9fbc15e6e7152034e609d6a7562d28dc45af2f
+    image: vova-medcenter-backend:87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#aa9fbc15e6e7152034e609d6a7562d28dc45af2f
+      context: https://github.com/Zent7/vova-medcenter.git#87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:aa9fbc15e6e7152034e609d6a7562d28dc45af2f
+    image: vova-medcenter-frontend:87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#aa9fbc15e6e7152034e609d6a7562d28dc45af2f
+      context: https://github.com/Zent7/vova-medcenter.git#87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit e4e70213b30780e37de068042d6f82bee0c70451.