### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb`
+- Upstream commit: `63afb50f6c32c97f0cbbac98349156d1e474115f`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
+    image: vova-medcenter-backend:63afb50f6c32c97f0cbbac98349156d1e474115f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
+      context: https://github.com/Zent7/vova-medcenter.git#63afb50f6c32c97f0cbbac98349156d1e474115f
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
+    image: vova-medcenter-frontend:63afb50f6c32c97f0cbbac98349156d1e474115f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#87adfad9ec1c9aca1c203bfc959d71b7bffdb1eb
+      context: https://github.com/Zent7/vova-medcenter.git#63afb50f6c32c97f0cbbac98349156d1e474115f
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 63afb50f6c32c97f0cbbac98349156d1e474115f.