### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `b5cc30bcdceab3d6b2b347861ae9802286495b28`
+- Upstream commit: `ef576a7d3853d610e9d13e8d87891bcc24ed3daa`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:b5cc30bcdceab3d6b2b347861ae9802286495b28
+    image: vova-medcenter-backend:ef576a7d3853d610e9d13e8d87891bcc24ed3daa
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b5cc30bcdceab3d6b2b347861ae9802286495b28
+      context: https://github.com/Zent7/vova-medcenter.git#ef576a7d3853d610e9d13e8d87891bcc24ed3daa
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:b5cc30bcdceab3d6b2b347861ae9802286495b28
+    image: vova-medcenter-frontend:ef576a7d3853d610e9d13e8d87891bcc24ed3daa
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b5cc30bcdceab3d6b2b347861ae9802286495b28
+      context: https://github.com/Zent7/vova-medcenter.git#ef576a7d3853d610e9d13e8d87891bcc24ed3daa
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit ef576a7d3853d610e9d13e8d87891bcc24ed3daa.