### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `ef576a7d3853d610e9d13e8d87891bcc24ed3daa`
+- Upstream commit: `672f226ff586b36ad613f56f148e6d8db4512c10`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:ef576a7d3853d610e9d13e8d87891bcc24ed3daa
+    image: vova-medcenter-backend:672f226ff586b36ad613f56f148e6d8db4512c10
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ef576a7d3853d610e9d13e8d87891bcc24ed3daa
+      context: https://github.com/Zent7/vova-medcenter.git#672f226ff586b36ad613f56f148e6d8db4512c10
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:ef576a7d3853d610e9d13e8d87891bcc24ed3daa
+    image: vova-medcenter-frontend:672f226ff586b36ad613f56f148e6d8db4512c10
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ef576a7d3853d610e9d13e8d87891bcc24ed3daa
+      context: https://github.com/Zent7/vova-medcenter.git#672f226ff586b36ad613f56f148e6d8db4512c10
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 672f226ff586b36ad613f56f148e6d8db4512c10.