### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `78c116fae7146ada73efa0d0b3136fa9799e215d`
+- Upstream commit: `1f36f2730c3c731523992672e2236b534b7bfd94`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:78c116fae7146ada73efa0d0b3136fa9799e215d
+    image: vova-medcenter-backend:1f36f2730c3c731523992672e2236b534b7bfd94
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#78c116fae7146ada73efa0d0b3136fa9799e215d
+      context: https://github.com/Zent7/vova-medcenter.git#1f36f2730c3c731523992672e2236b534b7bfd94
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:78c116fae7146ada73efa0d0b3136fa9799e215d
+    image: vova-medcenter-frontend:1f36f2730c3c731523992672e2236b534b7bfd94
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#78c116fae7146ada73efa0d0b3136fa9799e215d
+      context: https://github.com/Zent7/vova-medcenter.git#1f36f2730c3c731523992672e2236b534b7bfd94
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 1f36f2730c3c731523992672e2236b534b7bfd94.