### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:71c436af15ebd99dc13498047d77fcc93a715f23
+    image: vova-medcenter-backend:108964d98e9a6ab973f1ed7c0fd383f09ae21597
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#71c436af15ebd99dc13498047d77fcc93a715f23
+      context: https://github.com/Zent7/vova-medcenter.git#108964d98e9a6ab973f1ed7c0fd383f09ae21597
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:71c436af15ebd99dc13498047d77fcc93a715f23
+    image: vova-medcenter-frontend:108964d98e9a6ab973f1ed7c0fd383f09ae21597
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#71c436af15ebd99dc13498047d77fcc93a715f23
+      context: https://github.com/Zent7/vova-medcenter.git#108964d98e9a6ab973f1ed7c0fd383f09ae21597
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 108964d98e9a6ab973f1ed7c0fd383f09ae21597.