### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `e59181332b85d8ad0d6dd72706738c07ea0ea96c`
+- Upstream commit: `d63d7654839fd6b9541e57aac53107304d3a9920`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e59181332b85d8ad0d6dd72706738c07ea0ea96c
+    image: vova-medcenter-backend:d63d7654839fd6b9541e57aac53107304d3a9920
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e59181332b85d8ad0d6dd72706738c07ea0ea96c
+      context: https://github.com/Zent7/vova-medcenter.git#d63d7654839fd6b9541e57aac53107304d3a9920
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:e59181332b85d8ad0d6dd72706738c07ea0ea96c
+    image: vova-medcenter-frontend:d63d7654839fd6b9541e57aac53107304d3a9920
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e59181332b85d8ad0d6dd72706738c07ea0ea96c
+      context: https://github.com/Zent7/vova-medcenter.git#d63d7654839fd6b9541e57aac53107304d3a9920
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit d63d7654839fd6b9541e57aac53107304d3a9920.