### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `e043b8727dd02c501d0fd3335d0d1f3a0da8d638`
+- Upstream commit: `7881423881fc30f1954d3140979471eaea707eaf`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e043b8727dd02c501d0fd3335d0d1f3a0da8d638
+    image: vova-medcenter-backend:7881423881fc30f1954d3140979471eaea707eaf
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e043b8727dd02c501d0fd3335d0d1f3a0da8d638
+      context: https://github.com/Zent7/vova-medcenter.git#7881423881fc30f1954d3140979471eaea707eaf
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:e043b8727dd02c501d0fd3335d0d1f3a0da8d638
+    image: vova-medcenter-frontend:7881423881fc30f1954d3140979471eaea707eaf
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e043b8727dd02c501d0fd3335d0d1f3a0da8d638
+      context: https://github.com/Zent7/vova-medcenter.git#7881423881fc30f1954d3140979471eaea707eaf
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 7881423881fc30f1954d3140979471eaea707eaf.