### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `62fe6f68fdcf8015a31c9ca4b18e6c2fff7c79e4`
+- Upstream commit: `5692758783b326ad7f7376e0b49beea9d30d3ea4`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:62fe6f68fdcf8015a31c9ca4b18e6c2fff7c79e4
+    image: vova-medcenter-backend:5692758783b326ad7f7376e0b49beea9d30d3ea4
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#62fe6f68fdcf8015a31c9ca4b18e6c2fff7c79e4
+      context: https://github.com/Zent7/vova-medcenter.git#5692758783b326ad7f7376e0b49beea9d30d3ea4
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:62fe6f68fdcf8015a31c9ca4b18e6c2fff7c79e4
+    image: vova-medcenter-frontend:5692758783b326ad7f7376e0b49beea9d30d3ea4
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#62fe6f68fdcf8015a31c9ca4b18e6c2fff7c79e4
+      context: https://github.com/Zent7/vova-medcenter.git#5692758783b326ad7f7376e0b49beea9d30d3ea4
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 5692758783b326ad7f7376e0b49beea9d30d3ea4.