### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5692758783b326ad7f7376e0b49beea9d30d3ea4`
+- Upstream commit: `b76135afc8ba742b2a2e49b51f53226c0d6bb39b`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5692758783b326ad7f7376e0b49beea9d30d3ea4
+    image: vova-medcenter-backend:b76135afc8ba742b2a2e49b51f53226c0d6bb39b
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5692758783b326ad7f7376e0b49beea9d30d3ea4
+      context: https://github.com/Zent7/vova-medcenter.git#b76135afc8ba742b2a2e49b51f53226c0d6bb39b
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5692758783b326ad7f7376e0b49beea9d30d3ea4
+    image: vova-medcenter-frontend:b76135afc8ba742b2a2e49b51f53226c0d6bb39b
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5692758783b326ad7f7376e0b49beea9d30d3ea4
+      context: https://github.com/Zent7/vova-medcenter.git#b76135afc8ba742b2a2e49b51f53226c0d6bb39b
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit b76135afc8ba742b2a2e49b51f53226c0d6bb39b.