### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `b76135afc8ba742b2a2e49b51f53226c0d6bb39b`
+- Upstream commit: `b900242c8dddd2c9ba5d628634d2c73789839874`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:b76135afc8ba742b2a2e49b51f53226c0d6bb39b
+    image: vova-medcenter-backend:b900242c8dddd2c9ba5d628634d2c73789839874
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b76135afc8ba742b2a2e49b51f53226c0d6bb39b
+      context: https://github.com/Zent7/vova-medcenter.git#b900242c8dddd2c9ba5d628634d2c73789839874
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:b76135afc8ba742b2a2e49b51f53226c0d6bb39b
+    image: vova-medcenter-frontend:b900242c8dddd2c9ba5d628634d2c73789839874
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b76135afc8ba742b2a2e49b51f53226c0d6bb39b
+      context: https://github.com/Zent7/vova-medcenter.git#b900242c8dddd2c9ba5d628634d2c73789839874
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit b900242c8dddd2c9ba5d628634d2c73789839874.