### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `2d478bffcb399ecc5724fa096f31f01d5579d758`
+- Upstream commit: `83455b086a1ed802bbbc6369f1762cace7622d10`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:2d478bffcb399ecc5724fa096f31f01d5579d758
+    image: vova-medcenter-backend:83455b086a1ed802bbbc6369f1762cace7622d10
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#2d478bffcb399ecc5724fa096f31f01d5579d758
+      context: https://github.com/Zent7/vova-medcenter.git#83455b086a1ed802bbbc6369f1762cace7622d10
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:2d478bffcb399ecc5724fa096f31f01d5579d758
+    image: vova-medcenter-frontend:83455b086a1ed802bbbc6369f1762cace7622d10
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#2d478bffcb399ecc5724fa096f31f01d5579d758
+      context: https://github.com/Zent7/vova-medcenter.git#83455b086a1ed802bbbc6369f1762cace7622d10
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 83455b086a1ed802bbbc6369f1762cace7622d10.