### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8688e585a6466fc4d75bc101a69e800016c26994`
+- Upstream commit: `928d045d99d6d85bf519780e7c82a4b7453abf7b`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8688e585a6466fc4d75bc101a69e800016c26994
+    image: vova-medcenter-backend:928d045d99d6d85bf519780e7c82a4b7453abf7b
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8688e585a6466fc4d75bc101a69e800016c26994
+      context: https://github.com/Zent7/vova-medcenter.git#928d045d99d6d85bf519780e7c82a4b7453abf7b
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8688e585a6466fc4d75bc101a69e800016c26994
+    image: vova-medcenter-frontend:928d045d99d6d85bf519780e7c82a4b7453abf7b
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8688e585a6466fc4d75bc101a69e800016c26994
+      context: https://github.com/Zent7/vova-medcenter.git#928d045d99d6d85bf519780e7c82a4b7453abf7b
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 928d045d99d6d85bf519780e7c82a4b7453abf7b.