### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `ed8e95628ee6cb5424defdd662c2ee074c1cdbb8`
+- Upstream commit: `791a0a7eb8dbe5fee38a94b83501c7ffa78b933a`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:ed8e95628ee6cb5424defdd662c2ee074c1cdbb8
+    image: vova-medcenter-backend:791a0a7eb8dbe5fee38a94b83501c7ffa78b933a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ed8e95628ee6cb5424defdd662c2ee074c1cdbb8
+      context: https://github.com/Zent7/vova-medcenter.git#791a0a7eb8dbe5fee38a94b83501c7ffa78b933a
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:ed8e95628ee6cb5424defdd662c2ee074c1cdbb8
+    image: vova-medcenter-frontend:791a0a7eb8dbe5fee38a94b83501c7ffa78b933a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#ed8e95628ee6cb5424defdd662c2ee074c1cdbb8
+      context: https://github.com/Zent7/vova-medcenter.git#791a0a7eb8dbe5fee38a94b83501c7ffa78b933a
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 791a0a7eb8dbe5fee38a94b83501c7ffa78b933a.