### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `2ee794b88f448e928d9273afff66ccc0a8000d4f`
+- Upstream commit: `3bbddfc91e094fffa66822ee4ddf0da75eda419c`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:2ee794b88f448e928d9273afff66ccc0a8000d4f
+    image: vova-medcenter-backend:3bbddfc91e094fffa66822ee4ddf0da75eda419c
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#2ee794b88f448e928d9273afff66ccc0a8000d4f
+      context: https://github.com/Zent7/vova-medcenter.git#3bbddfc91e094fffa66822ee4ddf0da75eda419c
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:2ee794b88f448e928d9273afff66ccc0a8000d4f
+    image: vova-medcenter-frontend:3bbddfc91e094fffa66822ee4ddf0da75eda419c
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#2ee794b88f448e928d9273afff66ccc0a8000d4f
+      context: https://github.com/Zent7/vova-medcenter.git#3bbddfc91e094fffa66822ee4ddf0da75eda419c
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 3bbddfc91e094fffa66822ee4ddf0da75eda419c.