### PR TITLE
Increase vova-medcenter upload limit

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -82,6 +82,7 @@ services:
         server {
             listen 80;
             server_name _;
+            client_max_body_size 50m;
 
             root /usr/share/nginx/html;
             index index.html;


### PR DESCRIPTION
Raises the frontend nginx request body limit to 50 MB so Excel document templates can be uploaded.