### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `1d76790e66ffeb724c6993597299c00e04683fed`
+- Upstream commit: `981d990f9b60f88644744fb69f0c5cc00499ee9d`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:1d76790e66ffeb724c6993597299c00e04683fed
+    image: vova-medcenter-backend:981d990f9b60f88644744fb69f0c5cc00499ee9d
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1d76790e66ffeb724c6993597299c00e04683fed
+      context: https://github.com/Zent7/vova-medcenter.git#981d990f9b60f88644744fb69f0c5cc00499ee9d
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:1d76790e66ffeb724c6993597299c00e04683fed
+    image: vova-medcenter-frontend:981d990f9b60f88644744fb69f0c5cc00499ee9d
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1d76790e66ffeb724c6993597299c00e04683fed
+      context: https://github.com/Zent7/vova-medcenter.git#981d990f9b60f88644744fb69f0c5cc00499ee9d
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 981d990f9b60f88644744fb69f0c5cc00499ee9d.