### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8d637f573957af740f8c9d6259c7b2c0c981d46f`
+- Upstream commit: `12b2d2c5c2a026c7028db27e60eaae030d0a1141`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8d637f573957af740f8c9d6259c7b2c0c981d46f
+    image: vova-medcenter-backend:12b2d2c5c2a026c7028db27e60eaae030d0a1141
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8d637f573957af740f8c9d6259c7b2c0c981d46f
+      context: https://github.com/Zent7/vova-medcenter.git#12b2d2c5c2a026c7028db27e60eaae030d0a1141
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8d637f573957af740f8c9d6259c7b2c0c981d46f
+    image: vova-medcenter-frontend:12b2d2c5c2a026c7028db27e60eaae030d0a1141
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8d637f573957af740f8c9d6259c7b2c0c981d46f
+      context: https://github.com/Zent7/vova-medcenter.git#12b2d2c5c2a026c7028db27e60eaae030d0a1141
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 12b2d2c5c2a026c7028db27e60eaae030d0a1141.