### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `6585280cb0c4dbcb93245ca948afa5f11f4f018e`
+- Upstream commit: `ea202985cfda56a02aa72e1daa2f5701e89e15c4`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:6585280cb0c4dbcb93245ca948afa5f11f4f018e
+    image: vova-medcenter-backend:ea202985cfda56a02aa72e1daa2f5701e89e15c4
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6585280cb0c4dbcb93245ca948afa5f11f4f018e
+      context: https://github.com/Zent7/vova-medcenter.git#ea202985cfda56a02aa72e1daa2f5701e89e15c4
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:6585280cb0c4dbcb93245ca948afa5f11f4f018e
+    image: vova-medcenter-frontend:ea202985cfda56a02aa72e1daa2f5701e89e15c4
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6585280cb0c4dbcb93245ca948afa5f11f4f018e
+      context: https://github.com/Zent7/vova-medcenter.git#ea202985cfda56a02aa72e1daa2f5701e89e15c4
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit ea202985cfda56a02aa72e1daa2f5701e89e15c4.