### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `0527b05c4d5c493e3e968523bb5ceaa58f1f62e7`
+- Upstream commit: `3eede16853eea588e86a9502ce023023fc779b48`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:0527b05c4d5c493e3e968523bb5ceaa58f1f62e7
+    image: vova-medcenter-backend:3eede16853eea588e86a9502ce023023fc779b48
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#0527b05c4d5c493e3e968523bb5ceaa58f1f62e7
+      context: https://github.com/Zent7/vova-medcenter.git#3eede16853eea588e86a9502ce023023fc779b48
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:0527b05c4d5c493e3e968523bb5ceaa58f1f62e7
+    image: vova-medcenter-frontend:3eede16853eea588e86a9502ce023023fc779b48
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#0527b05c4d5c493e3e968523bb5ceaa58f1f62e7
+      context: https://github.com/Zent7/vova-medcenter.git#3eede16853eea588e86a9502ce023023fc779b48
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 3eede16853eea588e86a9502ce023023fc779b48.