### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `3eede16853eea588e86a9502ce023023fc779b48`
+- Upstream commit: `481f98d1cc9be1d7ad57827a3f7df290011629a8`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:3eede16853eea588e86a9502ce023023fc779b48
+    image: vova-medcenter-backend:481f98d1cc9be1d7ad57827a3f7df290011629a8
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#3eede16853eea588e86a9502ce023023fc779b48
+      context: https://github.com/Zent7/vova-medcenter.git#481f98d1cc9be1d7ad57827a3f7df290011629a8
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:3eede16853eea588e86a9502ce023023fc779b48
+    image: vova-medcenter-frontend:481f98d1cc9be1d7ad57827a3f7df290011629a8
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#3eede16853eea588e86a9502ce023023fc779b48
+      context: https://github.com/Zent7/vova-medcenter.git#481f98d1cc9be1d7ad57827a3f7df290011629a8
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 481f98d1cc9be1d7ad57827a3f7df290011629a8.