### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `481f98d1cc9be1d7ad57827a3f7df290011629a8`
+- Upstream commit: `daeff14f02bfc92a82d3de5ea2c496fd9c6377a2`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:481f98d1cc9be1d7ad57827a3f7df290011629a8
+    image: vova-medcenter-backend:daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#481f98d1cc9be1d7ad57827a3f7df290011629a8
+      context: https://github.com/Zent7/vova-medcenter.git#daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:481f98d1cc9be1d7ad57827a3f7df290011629a8
+    image: vova-medcenter-frontend:daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#481f98d1cc9be1d7ad57827a3f7df290011629a8
+      context: https://github.com/Zent7/vova-medcenter.git#daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit daeff14f02bfc92a82d3de5ea2c496fd9c6377a2.