### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `daeff14f02bfc92a82d3de5ea2c496fd9c6377a2`
+- Upstream commit: `307b0773e8d26d45316a63d57078d072dab9bf71`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
+    image: vova-medcenter-backend:307b0773e8d26d45316a63d57078d072dab9bf71
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
+      context: https://github.com/Zent7/vova-medcenter.git#307b0773e8d26d45316a63d57078d072dab9bf71
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
+    image: vova-medcenter-frontend:307b0773e8d26d45316a63d57078d072dab9bf71
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#daeff14f02bfc92a82d3de5ea2c496fd9c6377a2
+      context: https://github.com/Zent7/vova-medcenter.git#307b0773e8d26d45316a63d57078d072dab9bf71
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 307b0773e8d26d45316a63d57078d072dab9bf71.