### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `307b0773e8d26d45316a63d57078d072dab9bf71`
+- Upstream commit: `c978a05bb4f0c538df12f08ec18af49ae5451e86`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:307b0773e8d26d45316a63d57078d072dab9bf71
+    image: vova-medcenter-backend:c978a05bb4f0c538df12f08ec18af49ae5451e86
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#307b0773e8d26d45316a63d57078d072dab9bf71
+      context: https://github.com/Zent7/vova-medcenter.git#c978a05bb4f0c538df12f08ec18af49ae5451e86
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:307b0773e8d26d45316a63d57078d072dab9bf71
+    image: vova-medcenter-frontend:c978a05bb4f0c538df12f08ec18af49ae5451e86
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#307b0773e8d26d45316a63d57078d072dab9bf71
+      context: https://github.com/Zent7/vova-medcenter.git#c978a05bb4f0c538df12f08ec18af49ae5451e86
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit c978a05bb4f0c538df12f08ec18af49ae5451e86.