### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `aa40e569b2480dc1ad090434109260a2d43ff40e`
+- Upstream commit: `a461d15eae9bc2615169425c630d517d7e8f7aa3`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:aa40e569b2480dc1ad090434109260a2d43ff40e
+    image: vova-medcenter-backend:a461d15eae9bc2615169425c630d517d7e8f7aa3
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#aa40e569b2480dc1ad090434109260a2d43ff40e
+      context: https://github.com/Zent7/vova-medcenter.git#a461d15eae9bc2615169425c630d517d7e8f7aa3
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:aa40e569b2480dc1ad090434109260a2d43ff40e
+    image: vova-medcenter-frontend:a461d15eae9bc2615169425c630d517d7e8f7aa3
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#aa40e569b2480dc1ad090434109260a2d43ff40e
+      context: https://github.com/Zent7/vova-medcenter.git#a461d15eae9bc2615169425c630d517d7e8f7aa3
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit a461d15eae9bc2615169425c630d517d7e8f7aa3.