### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `a461d15eae9bc2615169425c630d517d7e8f7aa3`
+- Upstream commit: `5eda5d78e1626469262107d77ad4adf97444d301`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:a461d15eae9bc2615169425c630d517d7e8f7aa3
+    image: vova-medcenter-backend:5eda5d78e1626469262107d77ad4adf97444d301
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#a461d15eae9bc2615169425c630d517d7e8f7aa3
+      context: https://github.com/Zent7/vova-medcenter.git#5eda5d78e1626469262107d77ad4adf97444d301
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:a461d15eae9bc2615169425c630d517d7e8f7aa3
+    image: vova-medcenter-frontend:5eda5d78e1626469262107d77ad4adf97444d301
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#a461d15eae9bc2615169425c630d517d7e8f7aa3
+      context: https://github.com/Zent7/vova-medcenter.git#5eda5d78e1626469262107d77ad4adf97444d301
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 715b100e051b58d43c6c9a4e8318493f04c8f0f7.