### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `6a4b396b000f57057cedcbd0b9b6e7dfe396ce5f`
+- Upstream commit: `6242d53ffe1e068fd4ba32249b16025e9c9dccb0`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:6a4b396b000f57057cedcbd0b9b6e7dfe396ce5f
+    image: vova-medcenter-backend:6242d53ffe1e068fd4ba32249b16025e9c9dccb0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6a4b396b000f57057cedcbd0b9b6e7dfe396ce5f
+      context: https://github.com/Zent7/vova-medcenter.git#6242d53ffe1e068fd4ba32249b16025e9c9dccb0
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:6a4b396b000f57057cedcbd0b9b6e7dfe396ce5f
+    image: vova-medcenter-frontend:6242d53ffe1e068fd4ba32249b16025e9c9dccb0
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6a4b396b000f57057cedcbd0b9b6e7dfe396ce5f
+      context: https://github.com/Zent7/vova-medcenter.git#6242d53ffe1e068fd4ba32249b16025e9c9dccb0
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from compatible Zent7/vova-medcenter commit 6242d53ffe1e068fd4ba32249b16025e9c9dccb0.