### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `5703387ae86d033fa73245b727a389c2df3bbd5e`
+- Upstream commit: `eea7ac83fac3a7b81cc5a53792c824e750496f4f`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:5703387ae86d033fa73245b727a389c2df3bbd5e
+    image: vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5703387ae86d033fa73245b727a389c2df3bbd5e
+      context: https://github.com/Zent7/vova-medcenter.git#eea7ac83fac3a7b81cc5a53792c824e750496f4f
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:5703387ae86d033fa73245b727a389c2df3bbd5e
+    image: vova-medcenter-frontend:eea7ac83fac3a7b81cc5a53792c824e750496f4f
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#5703387ae86d033fa73245b727a389c2df3bbd5e
+      context: https://github.com/Zent7/vova-medcenter.git#eea7ac83fac3a7b81cc5a53792c824e750496f4f
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit eea7ac83fac3a7b81cc5a53792c824e750496f4f, fixing reliable certificate document opening.