### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `eea7ac83fac3a7b81cc5a53792c824e750496f4f`
+- Upstream commit: `1291fac38f576844e3fd5d6f12b7d6f66588e0f8`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f
+    image: vova-medcenter-backend:1291fac38f576844e3fd5d6f12b7d6f66588e0f8
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#eea7ac83fac3a7b81cc5a53792c824e750496f4f
+      context: https://github.com/Zent7/vova-medcenter.git#1291fac38f576844e3fd5d6f12b7d6f66588e0f8
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:eea7ac83fac3a7b81cc5a53792c824e750496f4f
+    image: vova-medcenter-frontend:1291fac38f576844e3fd5d6f12b7d6f66588e0f8
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#eea7ac83fac3a7b81cc5a53792c824e750496f4f
+      context: https://github.com/Zent7/vova-medcenter.git#1291fac38f576844e3fd5d6f12b7d6f66588e0f8
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 1291fac38f576844e3fd5d6f12b7d6f66588e0f8.