### PR TITLE
Restore stable vova-medcenter backend

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,8 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `1291fac38f576844e3fd5d6f12b7d6f66588e0f8`
+- Frontend commit: `544efd5956829925ae278df06e6ceefd2151829a`
+- Backend image: stable `eea7ac83fac3a7b81cc5a53792c824e750496f4f`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,38 +16,8 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:1291fac38f576844e3fd5d6f12b7d6f66588e0f8-retry1
-    pull_policy: build
-    build:
-      context: https://github.com/Zent7/vova-medcenter.git#1291fac38f576844e3fd5d6f12b7d6f66588e0f8
-      dockerfile_inline: |
-        FROM python:3.12-slim
-
-        ENV PYTHONDONTWRITEBYTECODE=1 \
-            PYTHONUNBUFFERED=1 \
-            PIP_NO_CACHE_DIR=1
-
-        WORKDIR /app
-
-        RUN apt-get update \
-            && apt-get install -y --no-install-recommends \
-                build-essential \
-                curl \
-                unixodbc-dev \
-            && rm -rf /var/lib/apt/lists/*
-
-        COPY backend/requirements.txt /app/requirements.txt
-        RUN pip install --upgrade pip \
-            && pip install -r /app/requirements.txt
-
-        COPY backend/ /app/
-        COPY assets/templates/ /assets/templates/
-        COPY frontend/public/ /app/frontend/public/
-        COPY frontend/public/ /frontend/public/
-
-        EXPOSE 8000
-
-        CMD ["sh", "-c", "python -m alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+    image: vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f
+    pull_policy: never
     container_name: vova-medcenter-backend
     restart: unless-stopped
     depends_on:
@@ -64,10 +34,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:1291fac38f576844e3fd5d6f12b7d6f66588e0f8-retry1
+    image: vova-medcenter-frontend:544efd5956829925ae278df06e6ceefd2151829a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#1291fac38f576844e3fd5d6f12b7d6f66588e0f8
+      context: https://github.com/Zent7/vova-medcenter.git#544efd5956829925ae278df06e6ceefd2151829a
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Restores the last stable local backend image after the new backend container remained unavailable, while deploying frontend commit 544efd5956829925ae278df06e6ceefd2151829a. The chairman blank replacement now uses existing stable blank APIs.