### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,8 +4,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Frontend commit: `544efd5956829925ae278df06e6ceefd2151829a`
-- Backend image: stable `eea7ac83fac3a7b81cc5a53792c824e750496f4f`
+- Upstream commit: `e5443edfabe5d0396883fcc7e7f5602e383df105`
+- Frontend image: `e5443edfabe5d0396883fcc7e7f5602e383df105`
+- Backend image: `e5443edfabe5d0396883fcc7e7f5602e383df105`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1
+    image: vova-medcenter-backend:e5443edfabe5d0396883fcc7e7f5602e383df105
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#eea7ac83fac3a7b81cc5a53792c824e750496f4f
+      context: https://github.com/Zent7/vova-medcenter.git#e5443edfabe5d0396883fcc7e7f5602e383df105
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:544efd5956829925ae278df06e6ceefd2151829a
+    image: vova-medcenter-frontend:e5443edfabe5d0396883fcc7e7f5602e383df105
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#544efd5956829925ae278df06e6ceefd2151829a
+      context: https://github.com/Zent7/vova-medcenter.git#e5443edfabe5d0396883fcc7e7f5602e383df105
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit e5443edfabe5d0396883fcc7e7f5602e383df105.