### PR TITLE
Restore vova-medcenter backend with stable base

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -6,7 +6,8 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `e5443edfabe5d0396883fcc7e7f5602e383df105`
 - Frontend image: `e5443edfabe5d0396883fcc7e7f5602e383df105`
-- Backend image: `e5443edfabe5d0396883fcc7e7f5602e383df105`
+- Backend image: `e5443edfabe5d0396883fcc7e7f5602e383df105-restore1`
+- Backend base image: stable `eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1`
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,38 +16,19 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e5443edfabe5d0396883fcc7e7f5602e383df105
+    image: vova-medcenter-backend:e5443edfabe5d0396883fcc7e7f5602e383df105-restore1
     pull_policy: build
     build:
       context: https://github.com/Zent7/vova-medcenter.git#e5443edfabe5d0396883fcc7e7f5602e383df105
       dockerfile_inline: |
-        FROM python:3.12-slim
-
-        ENV PYTHONDONTWRITEBYTECODE=1 \
-            PYTHONUNBUFFERED=1 \
-            PIP_NO_CACHE_DIR=1
+        FROM vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1
 
         WORKDIR /app
-
-        RUN apt-get update \
-            && apt-get install -y --no-install-recommends \
-                build-essential \
-                curl \
-                unixodbc-dev \
-            && rm -rf /var/lib/apt/lists/*
-
-        COPY backend/requirements.txt /app/requirements.txt
-        RUN pip install --upgrade pip \
-            && pip install -r /app/requirements.txt
 
         COPY backend/ /app/
         COPY assets/templates/ /assets/templates/
         COPY frontend/public/ /app/frontend/public/
         COPY frontend/public/ /frontend/public/
-
-        EXPOSE 8000
-
-        CMD ["sh", "-c", "python -m alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]
     container_name: vova-medcenter-backend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Layers the client-import fix over the previously verified backend image, avoiding a full dependency rebuild while keeping the new application revision.