### PR TITLE
Restore stable vova-medcenter backend image

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -6,8 +6,8 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `e5443edfabe5d0396883fcc7e7f5602e383df105`
 - Frontend image: `e5443edfabe5d0396883fcc7e7f5602e383df105`
-- Backend image: `e5443edfabe5d0396883fcc7e7f5602e383df105-restore1`
-- Backend base image: stable `eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1`
+- Backend image: stable `eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1`
+- Backend deployment: reuse the verified local image without rebuilding it
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,19 +16,8 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e5443edfabe5d0396883fcc7e7f5602e383df105-restore1
-    pull_policy: build
-    build:
-      context: https://github.com/Zent7/vova-medcenter.git#e5443edfabe5d0396883fcc7e7f5602e383df105
-      dockerfile_inline: |
-        FROM vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1
-
-        WORKDIR /app
-
-        COPY backend/ /app/
-        COPY assets/templates/ /assets/templates/
-        COPY frontend/public/ /app/frontend/public/
-        COPY frontend/public/ /frontend/public/
+    image: vova-medcenter-backend:eea7ac83fac3a7b81cc5a53792c824e750496f4f-restore1
+    pull_policy: never
     container_name: vova-medcenter-backend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Restores the last verified backend image without rebuilding it, while keeping the updated frontend and client-import workbook live.