### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,9 +4,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d`
-- Frontend image: `e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d`
-- Backend image: `e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d`
+- Upstream commit: `bd2b2d586a2446326c465f17957c6d46712294c1`
+- Frontend image: `bd2b2d586a2446326c465f17957c6d46712294c1`
+- Backend image: `bd2b2d586a2446326c465f17957c6d46712294c1`
 - Both application images build directly from the pinned upstream commit
 
 ## Architecture

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d
+    image: vova-medcenter-backend:bd2b2d586a2446326c465f17957c6d46712294c1
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d
+      context: https://github.com/Zent7/vova-medcenter.git#bd2b2d586a2446326c465f17957c6d46712294c1
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d
+    image: vova-medcenter-frontend:bd2b2d586a2446326c465f17957c6d46712294c1
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#e6dcc0ba1a9cea3ab4c7845d3a98652bf837e81d
+      context: https://github.com/Zent7/vova-medcenter.git#bd2b2d586a2446326c465f17957c6d46712294c1
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit bd2b2d586a2446326c465f17957c6d46712294c1.