### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `c5969ea8e756a6c3b9d80278e8ddf03a12761d36`
+- Upstream commit: `6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `3715c1942ca76f96be25a40763db4c6a41ca613d`
+- Upstream commit: `c5969ea8e756a6c3b9d80278e8ddf03a12761d36`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:c5969ea8e756a6c3b9d80278e8ddf03a12761d36
+    image: vova-medcenter-backend:6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#c5969ea8e756a6c3b9d80278e8ddf03a12761d36
+      context: https://github.com/Zent7/vova-medcenter.git#6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:c5969ea8e756a6c3b9d80278e8ddf03a12761d36
+    image: vova-medcenter-frontend:6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#c5969ea8e756a6c3b9d80278e8ddf03a12761d36
+      context: https://github.com/Zent7/vova-medcenter.git#6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:3715c1942ca76f96be25a40763db4c6a41ca613d
+    image: vova-medcenter-backend:c5969ea8e756a6c3b9d80278e8ddf03a12761d36
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#3715c1942ca76f96be25a40763db4c6a41ca613d
+      context: https://github.com/Zent7/vova-medcenter.git#c5969ea8e756a6c3b9d80278e8ddf03a12761d36
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:3715c1942ca76f96be25a40763db4c6a41ca613d
+    image: vova-medcenter-frontend:c5969ea8e756a6c3b9d80278e8ddf03a12761d36
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#3715c1942ca76f96be25a40763db4c6a41ca613d
+      context: https://github.com/Zent7/vova-medcenter.git#c5969ea8e756a6c3b9d80278e8ddf03a12761d36
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit c5969ea8e756a6c3b9d80278e8ddf03a12761d36.