### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7`
+- Upstream commit: `b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
+    image: vova-medcenter-backend:b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
+      context: https://github.com/Zent7/vova-medcenter.git#b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
+    image: vova-medcenter-frontend:b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#6bbc6a29522d66aeeffdc5c461e4a9fb18be5ca7
+      context: https://github.com/Zent7/vova-medcenter.git#b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a.