### PR TITLE
Deploy vova-medcenter VU date fix

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a`
+- Upstream commit: `614724b034474f16c8bea1d6cc747d4afa311612`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
+    image: vova-medcenter-backend:614724b034474f16c8bea1d6cc747d4afa311612
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
+      context: https://github.com/Zent7/vova-medcenter.git#614724b034474f16c8bea1d6cc747d4afa311612
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
+    image: vova-medcenter-frontend:614724b034474f16c8bea1d6cc747d4afa311612
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#b9ae8db9ce3414aaa31317ff75a9dff5ce04d58a
+      context: https://github.com/Zent7/vova-medcenter.git#614724b034474f16c8bea1d6cc747d4afa311612
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 614724b034474f16c8bea1d6cc747d4afa311612. Fixes the VU issue date display and renames the template/output to VU.xls.