### PR TITLE
Deploy final vova-medcenter VU fix

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `614724b034474f16c8bea1d6cc747d4afa311612`
+- Upstream commit: `0048cfe0ef2defce0901934320629d5729758ffb`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:614724b034474f16c8bea1d6cc747d4afa311612
+    image: vova-medcenter-backend:0048cfe0ef2defce0901934320629d5729758ffb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#614724b034474f16c8bea1d6cc747d4afa311612
+      context: https://github.com/Zent7/vova-medcenter.git#0048cfe0ef2defce0901934320629d5729758ffb
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:614724b034474f16c8bea1d6cc747d4afa311612
+    image: vova-medcenter-frontend:0048cfe0ef2defce0901934320629d5729758ffb
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#614724b034474f16c8bea1d6cc747d4afa311612
+      context: https://github.com/Zent7/vova-medcenter.git#0048cfe0ef2defce0901934320629d5729758ffb
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Deploys vova-medcenter commit 0048cfe0ef2defce0901934320629d5729758ffb. Includes the VU date/name fix, preserves the existing CHOD Word-template selection, and refreshes the frontend cache key.