### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `0048cfe0ef2defce0901934320629d5729758ffb`
+- Upstream commit: `711fb7a862ff74ce68bc91965cf459e13426b60e`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:0048cfe0ef2defce0901934320629d5729758ffb
+    image: vova-medcenter-backend:711fb7a862ff74ce68bc91965cf459e13426b60e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#0048cfe0ef2defce0901934320629d5729758ffb
+      context: https://github.com/Zent7/vova-medcenter.git#711fb7a862ff74ce68bc91965cf459e13426b60e
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:0048cfe0ef2defce0901934320629d5729758ffb
+    image: vova-medcenter-frontend:711fb7a862ff74ce68bc91965cf459e13426b60e
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#0048cfe0ef2defce0901934320629d5729758ffb
+      context: https://github.com/Zent7/vova-medcenter.git#711fb7a862ff74ce68bc91965cf459e13426b60e
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit 711fb7a862ff74ce68bc91965cf459e13426b60e.