### PR TITLE
Redeploy vova-medcenter stack

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -8,6 +8,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit
+- Last redeploy request: 2026-08-01 (recovery after overlapping stack updates)
 
 ## Architecture
 


### PR DESCRIPTION
Triggers one clean Komodo redeploy of the currently pinned vova-medcenter commit 0048cfe0ef2defce0901934320629d5729758ffb after overlapping deployment runs left the backend returning 502.