### PR TITLE
Redeploy vova-medcenter stack

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -8,7 +8,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit
-- Last redeploy request: 2026-08-01 (recovery after overlapping stack updates)
+- Last redeploy request: 2026-08-01 (recovery after completed tractor/VU rollout)
 
 ## Architecture
 


### PR DESCRIPTION
Triggers one clean Komodo redeploy after the overlapping VU and tractor-front rollout completed.