### PR TITLE
fix(isponsorblocktv): update screen_id to new 64-char format

### DIFF
--- a/k8s/apps/internal/isponsorblocktv/config.json
+++ b/k8s/apps/internal/isponsorblocktv/config.json
@@ -1,7 +1,7 @@
 {
   "devices": [
     {
-      "screen_id": "icj3el0sbvr9884n1cmonss4m8",
+      "screen_id": "cf33fdf538e9a1b7ac36146e1aaef0cedbcea9a4a28fefa9d939b3695894c769",
       "name": "YouTube on TV"
     }
   ],


### PR DESCRIPTION
YouTube revoked old 26-char screen IDs. Re-paired device and updated to new 64-hex format.