### PR TITLE
fix(renovate): disable automerge for cilium — critical infra

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -42,6 +42,12 @@
   ],
   "packageRules": [
     {
+      "description": "Cilium updates are critical infra — never automerge",
+      "matchPackageNames": ["cilium"],
+      "automerge": false,
+      "stabilityDays": 7
+    },
+    {
       "description": "Group all Docker major updates into one PR",
       "matchDatasources": ["docker"],
       "matchUpdateTypes": ["major"],


### PR DESCRIPTION
Cilium v1.20.0 update was auto-merged as 'minor' through helm minor/patch automerge rule, breaking all K8s services for 7+ hours because new Gateway API CRDs were required but not updated.

Now Cilium never auto-merges and has 7-day stability delay.