### PR TITLE
Restore vova-medcenter after failed rollout

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,7 +4,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `8981524fab8309fde6d3bc2659b35443f98b8caa`
+- Upstream commit: `980868768daa14eb5ee4afa97e3a821de179dcc8`
 - Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
 - Both application images build directly from the pinned upstream commit

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,10 +16,10 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8981524fab8309fde6d3bc2659b35443f98b8caa
+    image: vova-medcenter-backend:980868768daa14eb5ee4afa97e3a821de179dcc8
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8981524fab8309fde6d3bc2659b35443f98b8caa
+      context: https://github.com/Zent7/vova-medcenter.git#980868768daa14eb5ee4afa97e3a821de179dcc8
       dockerfile_inline: |
         FROM python:3.12-slim
 
@@ -64,10 +64,10 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8981524fab8309fde6d3bc2659b35443f98b8caa
+    image: vova-medcenter-frontend:980868768daa14eb5ee4afa97e3a821de179dcc8
     pull_policy: build
     build:
-      context: https://github.com/Zent7/vova-medcenter.git#8981524fab8309fde6d3bc2659b35443f98b8caa
+      context: https://github.com/Zent7/vova-medcenter.git#980868768daa14eb5ee4afa97e3a821de179dcc8
       dockerfile_inline: |
         FROM node:22-alpine AS build
         WORKDIR /app


### PR DESCRIPTION
Restores the last confirmed working application commit 980868768daa14eb5ee4afa97e3a821de179dcc8 after the new stack rollout left the public site returning 502.