### PR TITLE
Recover vova-medcenter backend from cached image

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -5,9 +5,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `980868768daa14eb5ee4afa97e3a821de179dcc8`
-- Frontend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
-- Backend image: `00bb811db07103bec4e2fcbe78363d3491a3599c`
-- Both application images build directly from the pinned upstream commit
+- Frontend image: `980868768daa14eb5ee4afa97e3a821de179dcc8`
+- Backend recovery image: `3715c1942ca76f96be25a40763db4c6a41ca613d` (cached; no registry/build required)
+- The frontend builds from the pinned upstream commit; the backend temporarily reuses the last working cached image while registry DNS is unavailable
 - Last redeploy request: 2026-08-01 (recovery after completed tractor/VU rollout)
 
 ## Architecture

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,38 +16,8 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:980868768daa14eb5ee4afa97e3a821de179dcc8
-    pull_policy: build
-    build:
-      context: https://github.com/Zent7/vova-medcenter.git#980868768daa14eb5ee4afa97e3a821de179dcc8
-      dockerfile_inline: |
-        FROM python:3.12-slim
-
-        ENV PYTHONDONTWRITEBYTECODE=1 \
-            PYTHONUNBUFFERED=1 \
-            PIP_NO_CACHE_DIR=1
-
-        WORKDIR /app
-
-        RUN apt-get update \
-            && apt-get install -y --no-install-recommends \
-                build-essential \
-                curl \
-                unixodbc-dev \
-            && rm -rf /var/lib/apt/lists/*
-
-        COPY backend/requirements.txt /app/requirements.txt
-        RUN pip install --upgrade pip \
-            && pip install -r /app/requirements.txt
-
-        COPY backend/ /app/
-        COPY assets/templates/ /assets/templates/
-        COPY frontend/public/ /app/frontend/public/
-        COPY frontend/public/ /frontend/public/
-
-        EXPOSE 8000
-
-        CMD ["sh", "-c", "python -m alembic upgrade head && exec uvicorn app.main:app --host 0.0.0.0 --port 8000"]
+    image: vova-medcenter-backend:3715c1942ca76f96be25a40763db4c6a41ca613d
+    pull_policy: never
     container_name: vova-medcenter-backend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Restores the live backend without Docker Hub or a rebuild by reusing the last working cached backend image 3715c19. The current frontend 9808687 remains unchanged and includes the GIMS series-selection fix.