### PR TITLE
Recover vova-medcenter entirely from cached images

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -5,10 +5,10 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `980868768daa14eb5ee4afa97e3a821de179dcc8`
-- Frontend image: `980868768daa14eb5ee4afa97e3a821de179dcc8`
+- Frontend recovery image: `00bb811db07103bec4e2fcbe78363d3491a3599c` (cached; no registry/build required)
 - Backend recovery image: `3715c1942ca76f96be25a40763db4c6a41ca613d` (cached; no registry/build required)
-- The frontend builds from the pinned upstream commit; the backend temporarily reuses the last working cached image while registry DNS is unavailable
-- Last redeploy request: 2026-08-01 17:49 MSK (retry cached-backend recovery after resource sync)
+- Both services temporarily reuse their last working cached images while registry DNS is unavailable
+- Last redeploy request: 2026-08-01 17:53 MSK (full cached-image recovery)
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -34,44 +34,8 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:980868768daa14eb5ee4afa97e3a821de179dcc8
-    pull_policy: build
-    build:
-      context: https://github.com/Zent7/vova-medcenter.git#980868768daa14eb5ee4afa97e3a821de179dcc8
-      dockerfile_inline: |
-        FROM node:22-alpine AS build
-        WORKDIR /app
-        COPY frontend/package*.json ./
-        RUN npm ci
-        COPY frontend/ ./
-        RUN npm run build
-
-        FROM nginx:1.27-alpine
-        COPY --from=build /app/dist /usr/share/nginx/html
-        COPY <<'EOF' /etc/nginx/conf.d/default.conf
-        server {
-            listen 80;
-            server_name _;
-            client_max_body_size 50m;
-
-            root /usr/share/nginx/html;
-            index index.html;
-
-            location /api/ {
-                proxy_pass http://backend:8000/api/;
-                proxy_http_version 1.1;
-                proxy_set_header Host $$host;
-                proxy_set_header X-Real-IP $$remote_addr;
-                proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-                proxy_set_header X-Forwarded-Proto $$scheme;
-            }
-
-            location / {
-                try_files $$uri $$uri/ /index.html;
-            }
-        }
-        EOF
-        EXPOSE 80
+    image: vova-medcenter-frontend:00bb811db07103bec4e2fcbe78363d3491a3599c
+    pull_policy: never
     container_name: vova-medcenter-frontend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Avoids all GitHub/registry build traffic during recovery: backend uses cached 3715c19 and frontend uses cached 00bb811 with pull_policy=never. This allows Compose to recreate the backend while external DNS/build access is unavailable, without touching the PostgreSQL volume.