### PR TITLE
Deploy LMK templates from cached backend base

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -6,9 +6,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `8981524fab8309fde6d3bc2659b35443f98b8caa`
 - Frontend image: `8981524-overlay`, built on cached image `00bb811db07103bec4e2fcbe78363d3491a3599c`
-- Backend image: `8981524fab8309fde6d3bc2659b35443f98b8caa` (cached and health-checked)
-- The frontend overlays the verified application sources onto its cached image, so no registry, npm, or pip download is required
-- Last redeploy request: 2026-08-01 (Docker overlay recovery with VU, tractor, and LMK template fixes)
+- Backend image: `8981524fab8309fde6d3bc2659b35443f98b8caa-cachebase1`
+- The frontend and backend overlay the verified application sources onto cached images, avoiding registry, npm, and pip downloads
+- Last redeploy request: 2026-08-01 (LMK templates with cached-backend recovery)
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,8 +16,19 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8981524fab8309fde6d3bc2659b35443f98b8caa
-    pull_policy: never
+    image: vova-medcenter-backend:8981524fab8309fde6d3bc2659b35443f98b8caa-cachebase1
+    pull_policy: build
+    build:
+      context: https://github.com/Zent7/vova-medcenter.git#8981524fab8309fde6d3bc2659b35443f98b8caa
+      dockerfile_inline: |
+        FROM vova-medcenter-backend:3715c1942ca76f96be25a40763db4c6a41ca613d
+
+        WORKDIR /app
+
+        COPY backend/ /app/
+        COPY assets/templates/ /assets/templates/
+        COPY frontend/public/ /app/frontend/public/
+        COPY frontend/public/ /frontend/public/
     container_name: vova-medcenter-backend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Builds app commit 8981524fab8309fde6d3bc2659b35443f98b8caa by copying its backend and templates onto the cached 3715c19 dependency image, avoiding unavailable package downloads. Also deploys the matching frontend. Adds the standalone LMK XLS and LMK certificate DOCX templates.