### PR TITLE
Deploy vova-medcenter frontend Docker overlay

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,11 +4,11 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream commit: `980868768daa14eb5ee4afa97e3a821de179dcc8`
-- Frontend recovery image: `00bb811db07103bec4e2fcbe78363d3491a3599c` (cached; no registry/build required)
-- Backend recovery image: `8981524fab8309fde6d3bc2659b35443f98b8caa` (cached; locally health-checked; no registry/build required)
-- Both services temporarily reuse their last working cached images while registry DNS is unavailable
-- Last redeploy request: 2026-08-01 18:00 MSK (fallback to health-checked backend cache)
+- Upstream commit: `8981524fab8309fde6d3bc2659b35443f98b8caa`
+- Frontend image: `8981524-overlay`, built on cached image `00bb811db07103bec4e2fcbe78363d3491a3599c`
+- Backend image: `8981524fab8309fde6d3bc2659b35443f98b8caa` (cached and health-checked)
+- The frontend overlays the verified application sources onto its cached image, so no registry, npm, or pip download is required
+- Last redeploy request: 2026-08-01 (Docker overlay recovery with VU, tractor, and LMK template fixes)
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -34,8 +34,14 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:00bb811db07103bec4e2fcbe78363d3491a3599c
-    pull_policy: never
+    image: vova-medcenter-frontend:8981524-overlay
+    pull_policy: build
+    build:
+      context: https://github.com/Zent7/vova-medcenter.git#8981524fab8309fde6d3bc2659b35443f98b8caa
+      dockerfile_inline: |
+        FROM vova-medcenter-frontend:00bb811db07103bec4e2fcbe78363d3491a3599c
+        COPY frontend/public/ /usr/share/nginx/html/
+        EXPOSE 80
     container_name: vova-medcenter-frontend
     restart: unless-stopped
     depends_on:


### PR DESCRIPTION
Deploys the verified vova-medcenter 8981524 frontend as a Docker overlay on the cached nginx image. The exact 8981524 backend image remains pinned and cached.