### PR TITLE
Recover vova-medcenter without registry builds

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -5,10 +5,10 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `8981524fab8309fde6d3bc2659b35443f98b8caa`
-- Frontend image: `8981524-overlay`, built on cached image `00bb811db07103bec4e2fcbe78363d3491a3599c`
-- Backend image: `8981524fab8309fde6d3bc2659b35443f98b8caa-cachebase1`
-- The frontend and backend overlay the verified application sources onto cached images, avoiding registry, npm, and pip downloads
-- Last redeploy request: 2026-08-01 (LMK templates with cached-backend recovery)
+- Frontend recovery: cached `nginx:1.27-alpine` proxies public assets from upstream commit `8981524fab8309fde6d3bc2659b35443f98b8caa` through jsDelivr
+- Backend recovery image: `3715c1942ca76f96be25a40763db4c6a41ca613d` (last known working cached image; no registry/build required)
+- This recovery path avoids Docker Registry access while preserving the current public frontend
+- Last redeploy request: 2026-08-01 (registry-free CDN recovery)
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,19 +16,8 @@ services:
       retries: 30
 
   backend:
-    image: vova-medcenter-backend:8981524fab8309fde6d3bc2659b35443f98b8caa-cachebase1
-    pull_policy: build
-    build:
-      context: https://github.com/Zent7/vova-medcenter.git#8981524fab8309fde6d3bc2659b35443f98b8caa
-      dockerfile_inline: |
-        FROM vova-medcenter-backend:3715c1942ca76f96be25a40763db4c6a41ca613d
-
-        WORKDIR /app
-
-        COPY backend/ /app/
-        COPY assets/templates/ /assets/templates/
-        COPY frontend/public/ /app/frontend/public/
-        COPY frontend/public/ /frontend/public/
+    image: vova-medcenter-backend:3715c1942ca76f96be25a40763db4c6a41ca613d
+    pull_policy: never
     container_name: vova-medcenter-backend
     restart: unless-stopped
     depends_on:
@@ -45,16 +34,13 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: vova-medcenter-frontend:8981524-overlay
-    pull_policy: build
-    build:
-      context: https://github.com/Zent7/vova-medcenter.git#8981524fab8309fde6d3bc2659b35443f98b8caa
-      dockerfile_inline: |
-        FROM vova-medcenter-frontend:00bb811db07103bec4e2fcbe78363d3491a3599c
-        COPY frontend/public/ /usr/share/nginx/html/
-        EXPOSE 80
+    image: nginx:1.27-alpine
+    pull_policy: never
     container_name: vova-medcenter-frontend
     restart: unless-stopped
+    configs:
+      - source: vova_medcenter_nginx
+        target: /etc/nginx/conf.d/default.conf
     depends_on:
       - backend
     networks:
@@ -76,3 +62,41 @@ networks:
   traefik:
     external: true
     name: traefik_default
+
+configs:
+  vova_medcenter_nginx:
+    content: |
+      server {
+          listen 80;
+          server_name _;
+          client_max_body_size 50m;
+
+          location = / {
+              return 302 /demo/index.html;
+          }
+
+          location /api/ {
+              proxy_pass http://backend:8000/api/;
+              proxy_http_version 1.1;
+              proxy_set_header Host $$host;
+              proxy_set_header X-Real-IP $$remote_addr;
+              proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
+              proxy_set_header X-Forwarded-Proto $$scheme;
+          }
+
+          location ~* \.html$$ {
+              resolver 1.1.1.1 1.0.0.1 valid=300s;
+              proxy_ssl_server_name on;
+              proxy_set_header Host cdn.jsdelivr.net;
+              proxy_pass https://cdn.jsdelivr.net/gh/Zent7/vova-medcenter@8981524fab8309fde6d3bc2659b35443f98b8caa/frontend/public$$request_uri;
+              proxy_hide_header Content-Type;
+              add_header Content-Type "text/html; charset=utf-8";
+          }
+
+          location / {
+              resolver 1.1.1.1 1.0.0.1 valid=300s;
+              proxy_ssl_server_name on;
+              proxy_set_header Host cdn.jsdelivr.net;
+              proxy_pass https://cdn.jsdelivr.net/gh/Zent7/vova-medcenter@8981524fab8309fde6d3bc2659b35443f98b8caa/frontend/public$$request_uri;
+          }
+      }


### PR DESCRIPTION
Uses the cached nginx and backend images while proxying the already-public frontend assets from the pinned upstream commit. This avoids registry, npm, and pip access during recovery.