### PR TITLE
Recover vova-medcenter with cached Python proxy

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -5,16 +5,16 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream commit: `8981524fab8309fde6d3bc2659b35443f98b8caa`
-- Frontend recovery: cached `nginx:1.27-alpine` proxies public assets from upstream commit `8981524fab8309fde6d3bc2659b35443f98b8caa` through jsDelivr
+- Frontend recovery: the cached backend image runs `recovery_server.py`, serving its bundled static files with the GIMS series-selection patch applied in memory
 - Backend recovery image: `3715c1942ca76f96be25a40763db4c6a41ca613d` (last known working cached image; no registry/build required)
-- This recovery path avoids Docker Registry access while preserving the current public frontend
+- This recovery path avoids Docker Registry, external DNS, npm, and pip access
 - Last redeploy request: 2026-08-01 (registry-free CDN recovery)
 
 ## Architecture
 
 - `db`: PostgreSQL 16 for demo data.
 - `backend`: FastAPI app. Runs Alembic migrations on start, then Uvicorn on `:8000`.
-- `frontend`: nginx serving the Vite build and proxying `/api/` to `backend:8000`.
+- `frontend`: a minimal Python recovery proxy serving the pinned public assets and forwarding `/api/` to `backend:8000`.
 
 The upstream repo currently ships only a local Windows/demo compose for Postgres, so this stack uses `dockerfile_inline` to keep the Komodo deployment self-contained while building directly from the pinned upstream Git commit.
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -34,13 +34,14 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: nginx:1.31-alpine
+    image: vova-medcenter-backend:3715c1942ca76f96be25a40763db4c6a41ca613d
     pull_policy: never
     container_name: vova-medcenter-frontend
     restart: unless-stopped
+    command: ["python", "/recovery_server.py"]
     configs:
-      - source: vova_medcenter_nginx
-        target: /etc/nginx/conf.d/default.conf
+      - source: vova_medcenter_recovery_server
+        target: /recovery_server.py
     depends_on:
       - backend
     networks:
@@ -64,39 +65,5 @@ networks:
     name: traefik_default
 
 configs:
-  vova_medcenter_nginx:
-    content: |
-      server {
-          listen 80;
-          server_name _;
-          client_max_body_size 50m;
-
-          location = / {
-              return 302 /demo/index.html;
-          }
-
-          location /api/ {
-              proxy_pass http://backend:8000/api/;
-              proxy_http_version 1.1;
-              proxy_set_header Host $$host;
-              proxy_set_header X-Real-IP $$remote_addr;
-              proxy_set_header X-Forwarded-For $$proxy_add_x_forwarded_for;
-              proxy_set_header X-Forwarded-Proto $$scheme;
-          }
-
-          location ~* \.html$$ {
-              resolver 1.1.1.1 1.0.0.1 valid=300s;
-              proxy_ssl_server_name on;
-              proxy_set_header Host cdn.jsdelivr.net;
-              proxy_pass https://cdn.jsdelivr.net/gh/Zent7/vova-medcenter@8981524fab8309fde6d3bc2659b35443f98b8caa/frontend/public$$request_uri;
-              proxy_hide_header Content-Type;
-              add_header Content-Type "text/html; charset=utf-8";
-          }
-
-          location / {
-              resolver 1.1.1.1 1.0.0.1 valid=300s;
-              proxy_ssl_server_name on;
-              proxy_set_header Host cdn.jsdelivr.net;
-              proxy_pass https://cdn.jsdelivr.net/gh/Zent7/vova-medcenter@8981524fab8309fde6d3bc2659b35443f98b8caa/frontend/public$$request_uri;
-          }
-      }
+  vova_medcenter_recovery_server:
+    file: ./recovery_server.py

--- a/komodo/stacks/vova-medcenter/recovery_server.py
+++ b/komodo/stacks/vova-medcenter/recovery_server.py
@@ -1,0 +1,181 @@
+from __future__ import annotations
+
+import http.server
+import pathlib
+import re
+import urllib.error
+import urllib.request
+
+
+STATIC_ROOT = pathlib.Path("/frontend/public")
+APP_JS_PATH = STATIC_ROOT / "demo" / "app.js"
+INDEX_PATH = STATIC_ROOT / "demo" / "index.html"
+HOP_BY_HOP_HEADERS = {
+    "connection",
+    "content-length",
+    "keep-alive",
+    "proxy-authenticate",
+    "proxy-authorization",
+    "te",
+    "trailer",
+    "transfer-encoding",
+    "upgrade",
+}
+
+
+def patched_app_js() -> bytes:
+    source = APP_JS_PATH.read_text(encoding="utf-8")
+    if "isPreselectedSeriesAvailable" in source:
+        return source.encode("utf-8")
+    availability_anchor = (
+        "  const storedSeries = getStoredDriverPrintSeries();\n"
+        "  const isStoredSeriesAvailable = availableSeriesOptions.some("
+    )
+    availability_replacement = (
+        "  const storedSeries = getStoredDriverPrintSeries();\n"
+        "  const isPreselectedSeriesAvailable = availableSeriesOptions.some(\n"
+        "    (item) => normalizeBlankSeries(item?.series).toLowerCase() === "
+        "preselectedSeries.toLowerCase(),\n"
+        "  );\n"
+        "  const isStoredSeriesAvailable = availableSeriesOptions.some("
+    )
+    selection_anchor = (
+        "      preselectedSeries ||\n"
+        "      (isStoredSeriesAvailable ? storedSeries : \"\") ||"
+    )
+    selection_replacement = (
+        "      (preselectedSeries && (isPreselectedSeriesAvailable || "
+        "!availableSeriesOptions.length) ? preselectedSeries : \"\") ||\n"
+        "      (isStoredSeriesAvailable ? storedSeries : \"\") ||"
+    )
+    if source.count(availability_anchor) != 1 or source.count(selection_anchor) != 1:
+        raise RuntimeError("Cached app.js does not match the expected recovery source")
+    source = source.replace(availability_anchor, availability_replacement, 1)
+    source = source.replace(selection_anchor, selection_replacement, 1)
+    return source.encode("utf-8")
+
+
+def patched_index_html() -> bytes:
+    source = INDEX_PATH.read_text(encoding="utf-8")
+    source, replacements = re.subn(
+        r'app\.js\?v=[^"\']+',
+        "app.js?v=20260801-blank-series-selection",
+        source,
+        count=1,
+    )
+    if replacements != 1:
+        raise RuntimeError("Cached index.html does not contain the app.js asset")
+    return source.encode("utf-8")
+
+
+PATCHED_APP_JS = patched_app_js()
+PATCHED_INDEX_HTML = patched_index_html()
+
+
+class RecoveryProxy(http.server.SimpleHTTPRequestHandler):
+    protocol_version = "HTTP/1.1"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, directory=str(STATIC_ROOT), **kwargs)
+
+    def _redirect_root(self) -> None:
+        self.send_response(http.HTTPStatus.FOUND)
+        self.send_header("Location", "/demo/index.html")
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+    def _serve_bytes(self, payload: bytes, content_type: str) -> None:
+        self.send_response(http.HTTPStatus.OK)
+        self.send_header("Content-Type", content_type)
+        self.send_header("Content-Length", str(len(payload)))
+        self.send_header("Cache-Control", "no-cache")
+        self.end_headers()
+        if self.command != "HEAD":
+            self.wfile.write(payload)
+
+    def _forward_api(self) -> None:
+        if self.path == "/":
+            self._redirect_root()
+            return
+
+        upstream = f"http://backend:8000{self.path}"
+        body_length = int(self.headers.get("Content-Length", "0"))
+        body = self.rfile.read(body_length) if body_length else None
+        headers = {
+            name: value
+            for name, value in self.headers.items()
+            if name.lower() not in HOP_BY_HOP_HEADERS
+            and name.lower() not in {"host", "accept-encoding"}
+        }
+        request = urllib.request.Request(
+            upstream,
+            data=body,
+            headers=headers,
+            method=self.command,
+        )
+
+        try:
+            response = urllib.request.urlopen(
+                request,
+                timeout=300,
+            )
+        except urllib.error.HTTPError as exc:
+            response = exc
+        except Exception as exc:
+            payload = f"Recovery proxy error: {exc}".encode("utf-8")
+            self.send_response(http.HTTPStatus.BAD_GATEWAY)
+            self.send_header("Content-Type", "text/plain; charset=utf-8")
+            self.send_header("Content-Length", str(len(payload)))
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(payload)
+            return
+
+        with response:
+            payload = b"" if self.command == "HEAD" else response.read()
+            self.send_response(response.status)
+            for name, value in response.headers.items():
+                lower_name = name.lower()
+                if lower_name in HOP_BY_HOP_HEADERS or lower_name == "content-type":
+                    continue
+                self.send_header(name, value)
+            content_type = response.headers.get_content_type()
+            charset = response.headers.get_content_charset()
+            if charset and content_type.startswith("text/"):
+                content_type = f"{content_type}; charset={charset}"
+            self.send_header("Content-Type", content_type)
+            content_length = response.headers.get("Content-Length")
+            self.send_header(
+                "Content-Length",
+                content_length if self.command == "HEAD" and content_length else str(len(payload)),
+            )
+            self.end_headers()
+            if self.command != "HEAD":
+                self.wfile.write(payload)
+
+    def _serve_static_or_api(self) -> None:
+        request_path = self.path.partition("?")[0]
+        if request_path == "/":
+            self._redirect_root()
+        elif request_path.startswith("/api/"):
+            self._forward_api()
+        elif request_path == "/demo/app.js":
+            self._serve_bytes(PATCHED_APP_JS, "application/javascript; charset=utf-8")
+        elif request_path == "/demo/index.html":
+            self._serve_bytes(PATCHED_INDEX_HTML, "text/html; charset=utf-8")
+        elif self.command == "HEAD":
+            super().do_HEAD()
+        else:
+            super().do_GET()
+
+    do_GET = _serve_static_or_api
+    do_HEAD = _serve_static_or_api
+    do_POST = _forward_api
+    do_PUT = _forward_api
+    do_PATCH = _forward_api
+    do_DELETE = _forward_api
+
+
+if __name__ == "__main__":
+    server = http.server.ThreadingHTTPServer(("0.0.0.0", 80), RecoveryProxy)
+    server.serve_forever()


### PR DESCRIPTION
Runs both services from the last cached backend image. The frontend process serves bundled static files, applies the GIMS blank-series fix in memory, and proxies API requests. No registry, external DNS, npm, or pip access is required.