### PR TITLE
Retry LMK blank type deployment

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -8,7 +8,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Frontend image: `ece0de9-offline-overlay`, built on cached image `980868768daa14eb5ee4afa97e3a821de179dcc8`
 - Backend image: `ece0de9-offline-overlay`, built on cached image `3715c1942ca76f96be25a40763db4c6a41ca613d`
 - Source and template overlays are bundled in this stack directory; the build performs no GitHub, registry, npm, or pip download
-- Last redeploy request: 2026-08-02 (LMK blank-type selection fix and verified Word template)
+- Last redeploy request: 2026-08-02 09:27 MSK (retry LMK blank-type selection fix)
 
 ## Architecture
 


### PR DESCRIPTION
Retries the Komodo deployment for the already merged LMK blank-type fix after the first accepted command did not restart the public containers.