### PR TITLE
Retry vova-medcenter 086 deployment

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -8,7 +8,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Frontend image: `5f681cd-offline-overlay`, built on cached image `980868768daa14eb5ee4afa97e3a821de179dcc8`
 - Backend image: `5f681cd-offline-overlay`, built on cached image `3715c1942ca76f96be25a40763db4c6a41ca613d`
 - Source and template overlays are bundled in this stack directory; the build performs no GitHub, registry, npm, or pip download
-- Last redeploy request: 2026-08-02 (086 sex rule and Word 2019 document-opening compatibility)
+- Last redeploy request: 2026-08-02 (retry 086 deployment after repository sync)
 
 ## Architecture
 


### PR DESCRIPTION
Retriggers the delegated Komodo deploy after homelab main has synchronized deployment commit 0e9f79e with vova-medcenter image 5f681cd.