### PR TITLE
Refresh Vova stack cache before delegated deploy

### DIFF
--- a/.github/workflows/vova-medcenter-delegated-merge.yml
+++ b/.github/workflows/vova-medcenter-delegated-merge.yml
@@ -95,6 +95,18 @@ jobs:
           echo "Timed out waiting for PR #$PR_NUMBER to merge."
           exit 1
 
+      - name: Refresh vova-medcenter stack cache in Komodo
+        env:
+          KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}
+          KOMODO_API_SECRET: ${{ secrets.KOMODO_API_SECRET }}
+        run: |
+          curl -sf -X POST https://komodo.ravil.space/write \
+            -H "Content-Type: application/json" \
+            -H "X-Api-Key: $KOMODO_API_KEY" \
+            -H "X-Api-Secret: $KOMODO_API_SECRET" \
+            -d '{"type":"RefreshStackCache","params":{"stack":"vova-medcenter"}}' \
+            > /dev/null
+
       - name: Deploy vova-medcenter in Komodo
         env:
           KOMODO_API_KEY: ${{ secrets.KOMODO_API_KEY }}


### PR DESCRIPTION
The delegated workflow currently calls DeployStack immediately after a bot-authored merge, but Komodo keeps its cached compose contents and redeploys the previous stack. RefreshStackCache is the documented write operation that refreshes remote repo contents/hash. This PR refreshes the vova-medcenter stack cache before DeployStack. After merging, one stack-scoped redeploy PR will publish the already-merged 086/client-import overlay from #510.