### PR TITLE
Retry client import deployment

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -8,7 +8,7 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Frontend image: `12a38bb-offline-overlay`, built on cached image `980868768daa14eb5ee4afa97e3a821de179dcc8`
 - Backend image: `12a38bb-offline-overlay`, built on cached image `3715c1942ca76f96be25a40763db4c6a41ca613d`
 - Source and template overlays are bundled in this stack directory; the build performs no GitHub, registry, npm, or pip download
-- Last redeploy request: 2026-08-02 (086 sex rules and Word 2019 opening, with current client import)
+- Last redeploy request: 2026-08-02 (retry combined 086 and client-import deployment after queue drain)
 
 ## Architecture
 


### PR DESCRIPTION
Retries DeployStack after the combined 086 and client-import overlay was merged but the public container did not refresh.