### PR TITLE
fix: use available vova frontend overlay base

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -45,7 +45,9 @@ services:
     build:
       context: .
       dockerfile_inline: |
-        FROM vova-medcenter-frontend:12a38bb-offline-overlay
+        # 5f694c6 is the offline frontend base currently present on Komodo;
+        # 12a38bb is absent there, which makes rebuilds try Docker Hub and fail.
+        FROM vova-medcenter-frontend:5f694c6-offline-overlay
         COPY frontend-overlay-8081148.tar.gz.b64 /tmp/frontend-overlay.tar.gz.b64
         RUN base64 -d /tmp/frontend-overlay.tar.gz.b64 > /tmp/frontend-overlay.tar.gz && tar -xzf /tmp/frontend-overlay.tar.gz -C / && rm -f /tmp/frontend-overlay.tar.gz.b64 /tmp/frontend-overlay.tar.gz
     container_name: vova-medcenter-frontend


### PR DESCRIPTION
## Summary
- update vova-medcenter frontend overlay build to use the locally available `vova-medcenter-frontend:5f694c6-offline-overlay` base
- document why `12a38bb-offline-overlay` is not usable on Komodo: it is absent locally, so Docker tries to pull `docker.io/library/vova-medcenter-frontend:12a38bb-offline-overlay` and fails
- leave backend unchanged

## Live evidence
- Komodo copied compose wants `vova-medcenter-frontend:8081148-chairman-cards-overlay`
- normal `docker compose build frontend` failed resolving `vova-medcenter-frontend:12a38bb-offline-overlay`
- manual build from `5f694c6-offline-overlay` succeeded and live frontend now serves `renderSanatoriumChairmanClassic`

## Verification
- `docker compose -f komodo/stacks/vova-medcenter/compose.yaml config`