### PR TITLE
Deploy grouped blank batch filter

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,11 +4,11 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream application revision: `e641488b8d501efbe2764d4aee15e5b648cddb8e`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:e641488b8d501efbe2764d4aee15e5b648cddb8e@sha256:705fe976ca5caa1d02fbede61a30d406c75ed011cc4acaa9f86dbb87fc6e0572`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:e641488b8d501efbe2764d4aee15e5b648cddb8e@sha256:c595d7f5a6b1dc0fdbf5853a6956c12824ebef00e889c6993c5d327c3b859fa5`
+- Upstream application revision: `508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998@sha256:448529136dd4d8bc34271c74fc75178ed575a16455c4aac929e3ea9aecea1277`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998@sha256:bd87181060ece3793c12d941c2e59f0d3229e7afcf7b9cc251aa87dddf230e94`
 - Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag pinned to its OCI digest
-- Last redeploy request: 2026-08-16 (require exact GIMS typographic blank numbers)
+- Last redeploy request: 2026-08-16 (group blank number ranges by certificate type)
 
 ## Architecture
 
@@ -50,7 +50,7 @@ Expected response shape:
 ## Verification
 
 ```bash
-./verify-deployment.sh e641488b8d501efbe2764d4aee15e5b648cddb8e
+./verify-deployment.sh 508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998
 curl -sk -o /dev/null -w '%{http_code}\n' https://vova-medcenter.ravil.space/
 curl -sk https://vova-medcenter.ravil.space/api/v1/health
 curl -sk 'https://vova-medcenter.ravil.space/api/v1/clients?limit=1'

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:e641488b8d501efbe2764d4aee15e5b648cddb8e@sha256:c595d7f5a6b1dc0fdbf5853a6956c12824ebef00e889c6993c5d327c3b859fa5
+    image: ghcr.io/zent7/vova-medcenter-backend:508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998@sha256:bd87181060ece3793c12d941c2e59f0d3229e7afcf7b9cc251aa87dddf230e94
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -34,7 +34,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:e641488b8d501efbe2764d4aee15e5b648cddb8e@sha256:705fe976ca5caa1d02fbede61a30d406c75ed011cc4acaa9f86dbb87fc6e0572
+    image: ghcr.io/zent7/vova-medcenter-frontend:508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998@sha256:448529136dd4d8bc34271c74fc75178ed575a16455c4aac929e3ea9aecea1277
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -63,7 +63,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: e641488b8d501efbe2764d4aee15e5b648cddb8e
+      EXPECTED_REVISION: 508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to application commit 508d93eaff6a2d1bc99f6e3c6d7eddb9426a5998 from https://github.com/Zent7/vova-medcenter/pull/25.

- Pins both GHCR images to immutable OCI digests.
- Updates the release verifier revision.
- Changes only komodo/stacks/vova-medcenter/.