### PR TITLE
Pin final editable XLS application revision

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:c71d55c630f5ab344b072bbe34df83896d89eafe
+    image: ghcr.io/zent7/vova-medcenter-backend:f5c46ed6a6b559a44f78466cfe530d618d0a1f26
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:c71d55c630f5ab344b072bbe34df83896d89eafe
+    image: ghcr.io/zent7/vova-medcenter-frontend:f5c46ed6a6b559a44f78466cfe530d618d0a1f26
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: c71d55c630f5ab344b072bbe34df83896d89eafe
+      EXPECTED_REVISION: f5c46ed6a6b559a44f78466cfe530d618d0a1f26
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Pins vova-medcenter backend/frontend to application commit f5c46ed6a6b559a44f78466cfe530d618d0a1f26 from Zent7/vova-medcenter#31. The persistent template-overrides volume was already added by #559; this follow-up delivers the completed legacy XLS marker migration and cleaned GIMS template.\n\nVerification: 107 backend tests, compileall, Vite production build, Docker Compose config, and real Excel row/column insertion smoke across VU, Amb, PZ2 and Prof2.