### PR TITLE
Deploy final editable XLS application revision

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -5,8 +5,8 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
 - Upstream application revision: `aa0f22fd7f8ac821abdb998515fc86d3e36f1623`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623@sha256:e2ca5dc2b7893dcb7391129763c4a516f4a1dda40677aad21556ee4d3f3cd66f`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623@sha256:0616b1a85373e746e2c2059f08ce811f398cc9836504e05ec52d9e594adc5803`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:e8e6957334d806a2eaf0821b2f0d7db096976ad5`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:e8e6957334d806a2eaf0821b2f0d7db096976ad5`
 - Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag pinned to its OCI digest
 - Last redeploy request: 2026-08-19 (keep only the approved certificate list)
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:f5c46ed6a6b559a44f78466cfe530d618d0a1f26
+    image: ghcr.io/zent7/vova-medcenter-backend:e8e6957334d806a2eaf0821b2f0d7db096976ad5
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:f5c46ed6a6b559a44f78466cfe530d618d0a1f26
+    image: ghcr.io/zent7/vova-medcenter-frontend:e8e6957334d806a2eaf0821b2f0d7db096976ad5
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: f5c46ed6a6b559a44f78466cfe530d618d0a1f26
+      EXPECTED_REVISION: e8e6957334d806a2eaf0821b2f0d7db096976ad5
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Deploys vova-medcenter backend/frontend images built successfully from main commit e8e6957334d806a2eaf0821b2f0d7db096976ad5. Updates the release verifier and stack documentation to the same immutable SHA.