### PR TITLE
Deploy editable XLS on current live revision

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,9 +4,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream application revision: `aa0f22fd7f8ac821abdb998515fc86d3e36f1623`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623@sha256:e2ca5dc2b7893dcb7391129763c4a516f4a1dda40677aad21556ee4d3f3cd66f`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623@sha256:0616b1a85373e746e2c2059f08ce811f398cc9836504e05ec52d9e594adc5803`
+- Upstream application revision: `a6c6a8095534f778dc8051c1e1a2627619ecfb70`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:a6c6a8095534f778dc8051c1e1a2627619ecfb70`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:a6c6a8095534f778dc8051c1e1a2627619ecfb70`
 - Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag pinned to its OCI digest
 - Last redeploy request: 2026-08-19 (keep only the approved certificate list)
 
@@ -50,7 +50,7 @@ Expected response shape:
 ## Verification
 
 ```bash
-./verify-deployment.sh aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+./verify-deployment.sh a6c6a8095534f778dc8051c1e1a2627619ecfb70
 curl -sk -o /dev/null -w '%{http_code}\n' https://vova-medcenter.ravil.space/
 curl -sk https://vova-medcenter.ravil.space/api/v1/health
 curl -sk 'https://vova-medcenter.ravil.space/api/v1/clients?limit=1'

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+    image: ghcr.io/zent7/vova-medcenter-backend:a6c6a8095534f778dc8051c1e1a2627619ecfb70
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+    image: ghcr.io/zent7/vova-medcenter-frontend:a6c6a8095534f778dc8051c1e1a2627619ecfb70
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+      EXPECTED_REVISION: a6c6a8095534f778dc8051c1e1a2627619ecfb70
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Deploys the successfully built backend/frontend images for a6c6a8095534f778dc8051c1e1a2627619ecfb70. This revision is based directly on the previously healthy live SHA aa0f22fd7f8ac821abdb998515fc86d3e36f1623 and adds only the completed editable XLS template work.