### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,10 +4,10 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream application revision: `76b4b262323416e79856eb6e468c3589e6260982`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:76b4b262323416e79856eb6e468c3589e6260982@sha256:0ecaa5d3ba65b4ed09381a36a0cdb87a0c7fb1ce4a39de21fd3586993edc798f`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:76b4b262323416e79856eb6e468c3589e6260982@sha256:ff30fe41251e0512685c84ce05f2cfe7c758ba01b472f65e6270f1ba69fb827e`
-- Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag pinned to its OCI digest
+- Upstream application revision: `c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5`
+- Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag.
 - Last redeploy request: 2026-08-20 (fix LMK blank series scope)
 
 ## Architecture

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:76b4b262323416e79856eb6e468c3589e6260982
+    image: ghcr.io/zent7/vova-medcenter-backend:c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:76b4b262323416e79856eb6e468c3589e6260982
+    image: ghcr.io/zent7/vova-medcenter-frontend:c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: 76b4b262323416e79856eb6e468c3589e6260982
+      EXPECTED_REVISION: c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Updates the vova-medcenter Komodo stack to build from Zent7/vova-medcenter commit c1b62ef1bf52afbf6ed83b0a9f32cd9e8eb32cd5.