### PR TITLE
fix(paperless-ngx): move prompts volume outside git repo

### DIFF
--- a/komodo/stacks/paperless-ngx/compose.yaml
+++ b/komodo/stacks/paperless-ngx/compose.yaml
@@ -105,7 +105,7 @@ services:
       LLM_LANGUAGE: "German"
       CREATE_NEW_TAGS: "false"
     volumes:
-      - ./prompts:/app/prompts
+      - /etc/komodo/stacks/paperless-ngx/prompts:/app/prompts
     ports:
       - "8083:8080"
     depends_on:


### PR DESCRIPTION
## Problem
paperless-gpt bind-mounts `./prompts:/app/prompts` which resolves to the git working tree. Runtime writes create untracked files, breaking `git pull` and Komodo resource sync.

## Fix
Change to absolute path `/etc/komodo/stacks/paperless-ngx/prompts` — outside the repo-cache entirely.