### PR TITLE
Update vova-medcenter deployment commit

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,9 +4,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream application revision: `aa0f22fd7f8ac821abdb998515fc86d3e36f1623`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623`
+- Upstream application revision: `00938aa0a80beeaabd8991671c6b9bc77eedd760`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:00938aa0a80beeaabd8991671c6b9bc77eedd760`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:00938aa0a80beeaabd8991671c6b9bc77eedd760`
 - Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag.
 - Last redeploy request: 2026-08-20 (fix LMK blank series scope)
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+    image: ghcr.io/zent7/vova-medcenter-backend:00938aa0a80beeaabd8991671c6b9bc77eedd760
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+    image: ghcr.io/zent7/vova-medcenter-frontend:00938aa0a80beeaabd8991671c6b9bc77eedd760
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: aa0f22fd7f8ac821abdb998515fc86d3e36f1623
+      EXPECTED_REVISION: 00938aa0a80beeaabd8991671c6b9bc77eedd760
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Deploys Zent7/vova-medcenter commit 00938aa0a80beeaabd8991671c6b9bc77eedd760 with the blanks and templates UI updates.