### PR TITLE
fix: resolve merge conflict in stacks.toml — separate ha and proxmox stacks

### DIFF
--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,43 @@
+name: Stale PRs
+
+on:
+  schedule:
+    - cron: '0 4 * * *'  # daily at 4am UTC (6am Berlin)
+  workflow_dispatch:      # manual trigger for testing
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          # PR config
+          days-before-pr-stale: 30
+          days-before-pr-close: 7
+          stale-pr-label: stale
+          close-pr-label: wontfix
+          exempt-pr-labels: pinned,security,do-not-stale
+
+          # Messages
+          stale-pr-message: >
+            👋 This PR has been marked as **stale** due to 30 days of inactivity.
+            If no activity occurs within 7 days, it will be automatically closed.
+            Feel free to keep it open by pushing a new commit or leaving a comment.
+
+          close-pr-message: >
+            🔒 Closing as stale. This PR has had no activity for 37+ days.
+            If this is still relevant, feel free to reopen or open a new PR.
+
+          # Don't mark issues (only PRs)
+          days-before-issue-stale: -1
+          days-before-issue-close: -1
+
+          # Batch size
+          operations-per-run: 30
+
+          # Enable debug (shows which PRs would be affected on dry-run)
+          debug-only: false

--- a/komodo/stacks.toml
+++ b/komodo/stacks.toml
@@ -53,26 +53,28 @@ branch = "main"
 run_directory = "komodo/stacks/pocketid"
 
 [[stack]]
-<<<<<<< HEAD
 name = "proxmox"
 description = "Proxmox VE web UI — router-only proxy to 192.168.1.100:8006"
 tags = ["infra"]
-=======
-name = "ha"
-description = "Home Assistant — router-only proxy to 192.168.1.153:8123"
-tags = ["infra", "home-automation"]
->>>>>>> 7544618 (feat: migrate home-assistant ingress from K8s to Komodo/Traefik)
 deploy = true
 auto_update = true
 [stack.config]
 server_id = "Local"
 repo = "ravilushqa/homelab"
 branch = "main"
-<<<<<<< HEAD
 run_directory = "komodo/stacks/proxmox"
-=======
+
+[[stack]]
+name = "ha"
+description = "Home Assistant — router-only proxy to 192.168.1.153:8123"
+tags = ["infra", "home-automation"]
+deploy = true
+auto_update = true
+[stack.config]
+server_id = "Local"
+repo = "ravilushqa/homelab"
+branch = "main"
 run_directory = "komodo/stacks/ha"
->>>>>>> 7544618 (feat: migrate home-assistant ingress from K8s to Komodo/Traefik)
 
 # ─── Monitoring ──────────────────────────────────────────────────
 


### PR DESCRIPTION
## Problem
After merging `feat: migrate home-assistant ingress from K8s to Komodo/Traefik` (7544618), git conflict markers were left in `komodo/stacks.toml`. The `ha` and `proxmox` stack entries were fused into one broken TOML block.

**Result:** Komodo resource sync couldn't parse the file → `ha` stack was never created on disk → Traefik returned **404** for `ha.ravil.space`.

## Fix
Split the merged block into two valid `[[stack]]` entries — one for `proxmox` (router-only proxy to 192.168.1.100:8006) and one for `ha` (router-only proxy to 192.168.1.153:8123).

## Verified
- HA backend at `192.168.1.153:8123` responds 200 ✅
- TCP routing already correct (ha removed from k8s-tcp-router in prior merge) ✅
- TOML now has 2 separate valid entries ✅

After merge, Komodo resource sync will create the stack and deploy the router-only proxy container.