### PR TITLE
fix: remove passHostHeader from HA router-only proxy

### DIFF
--- a/komodo/stacks/ha/compose.yaml
+++ b/komodo/stacks/ha/compose.yaml
@@ -11,7 +11,6 @@ services:
       - "traefik.http.routers.ha.tls.certresolver=cloudflare"
       # No OIDC — Home Assistant has its own auth
       - "traefik.http.services.ha-svc.loadbalancer.server.url=http://192.168.1.153:8123"
-      - "traefik.http.services.ha-svc.loadbalancer.passHostHeader=true"
 
 networks:
   traefik_default:


### PR DESCRIPTION
## Problem
After fixing the merge conflict in `stacks.toml`, the HA router-only proxy container deployed but returned **400** instead of 200.

## Root cause
`passHostHeader=true` caused Traefik to forward `Host: ha.ravil.space` to HA backend. While HA accepts this header when queried directly (tested: `curl -H 'Host: ha.ravil.space' http://192.168.1.153:8123/` → 200), through Traefik's HTTP/2→HTTP/1.1 proxying it produces a Traefik-level 400 error.

## Fix
Remove `passHostHeader=true` from the HA compose. Traefik will use its default behavior (set Host to backend's IP/port), which HA accepts.

Note: pocketid and proxmox router-only proxies keep `passHostHeader=true` — they work correctly with it. HA's Python aiohttp server behaves differently.