### PR TITLE
Use published vova-medcenter images

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,9 +4,9 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream application revision: `0f02ea37d14aa1bc365d27bbe54723ba67c41ca8`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:0f02ea37d14aa1bc365d27bbe54723ba67c41ca8`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:0f02ea37d14aa1bc365d27bbe54723ba67c41ca8`
+- Upstream application revision: `670d84e7897eebba6740b3f01855c5534d183773`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:670d84e7897eebba6740b3f01855c5534d183773`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:670d84e7897eebba6740b3f01855c5534d183773`
 - Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag.
 - Last redeploy request: 2026-08-22 (paginate blank number list)
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:0f02ea37d14aa1bc365d27bbe54723ba67c41ca8
+    image: ghcr.io/zent7/vova-medcenter-backend:670d84e7897eebba6740b3f01855c5534d183773
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:0f02ea37d14aa1bc365d27bbe54723ba67c41ca8
+    image: ghcr.io/zent7/vova-medcenter-frontend:670d84e7897eebba6740b3f01855c5534d183773
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: 0f02ea37d14aa1bc365d27bbe54723ba67c41ca8
+      EXPECTED_REVISION: 670d84e7897eebba6740b3f01855c5534d183773
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
Fixes the vova-medcenter deployment to use published GHCR images from app commit 670d84e7897eebba6740b3f01855c5534d183773. Previous handoff pointed at 0f02ea37d14aa1bc365d27bbe54723ba67c41ca8, which did not have images published.