### PR TITLE
deploy: update vova-medcenter cash fix

### DIFF
--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:670d84e7897eebba6740b3f01855c5534d183773
+    image: ghcr.io/zent7/vova-medcenter-backend:3269ebab0d2f58812e5eacf80bffd635806ced64
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:670d84e7897eebba6740b3f01855c5534d183773
+    image: ghcr.io/zent7/vova-medcenter-frontend:3269ebab0d2f58812e5eacf80bffd635806ced64
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: 670d84e7897eebba6740b3f01855c5534d183773
+      EXPECTED_REVISION: 3269ebab0d2f58812e5eacf80bffd635806ced64
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
## Summary
- deploy vova-medcenter backend/frontend images from Zent7/vova-medcenter@3269ebab
- includes cash page fix: cash report now loads paid payments from backend DB by period/center instead of browser localStorage

## Verification
- source PR CI published both images: https://github.com/Zent7/vova-medcenter/actions/runs/32570587631
- backend unit suite: 109 tests OK
- frontend build/test passed in source repo