### PR TITLE
revert: keep Karakeep Meilisearch on v1.35.1

### DIFF
--- a/komodo/stacks/karakeep/compose.yaml
+++ b/komodo/stacks/karakeep/compose.yaml
@@ -45,7 +45,7 @@ services:
       - --hide-scrollbars
 
   meilisearch:
-    image: getmeili/meilisearch:v1.53.1
+    image: getmeili/meilisearch:v1.35.1
     container_name: karakeep-meilisearch
     restart: unless-stopped
     environment:


### PR DESCRIPTION
Reverts #90 because live Meilisearch failed to start after v1.53.1 deploy: database version 1.35.1 is incompatible unless `--upgrade-db`/`MEILI_UPGRADE_DB` is used. Keeping the old image restores the running Karakeep search container.