### PR TITLE
chore: deploy vova medcenter start page auth gate

### DIFF
--- a/komodo/stacks/vova-medcenter/README.md
+++ b/komodo/stacks/vova-medcenter/README.md
@@ -4,11 +4,11 @@ Demo deployment for [`Zent7/vova-medcenter`](https://github.com/Zent7/vova-medce
 
 - Public URL: https://vova-medcenter.ravil.space
 - Demo UI: https://vova-medcenter.ravil.space/demo/index.html
-- Upstream application revision: `670d84e7897eebba6740b3f01855c5534d183773`
-- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:670d84e7897eebba6740b3f01855c5534d183773`
-- Backend image: `ghcr.io/zent7/vova-medcenter-backend:670d84e7897eebba6740b3f01855c5534d183773`
+- Upstream application revision: `ecd18145daa41c1dff698c9d438bc1ac313ea3aa`
+- Frontend image: `ghcr.io/zent7/vova-medcenter-frontend:ecd18145daa41c1dff698c9d438bc1ac313ea3aa@sha256:3baebe11d95066fd6e38a006081c31fc65c4d56889734392d7eb025e64eac737`
+- Backend image: `ghcr.io/zent7/vova-medcenter-backend:ecd18145daa41c1dff698c9d438bc1ac313ea3aa@sha256:d11a394d980605acc7a2663abafc35fae3027f33d7716bd63267346f4c377413`
 - Both images are immutable GitHub Actions artifacts; Komodo pulls the exact full-SHA tag.
-- Last redeploy request: 2026-08-22 (paginate blank number list)
+- Last redeploy request: 2026-08-22 (start page auth gate)
 
 ## Architecture
 

--- a/komodo/stacks/vova-medcenter/compose.yaml
+++ b/komodo/stacks/vova-medcenter/compose.yaml
@@ -16,7 +16,7 @@ services:
       retries: 30
 
   backend:
-    image: ghcr.io/zent7/vova-medcenter-backend:3269ebab0d2f58812e5eacf80bffd635806ced64
+    image: ghcr.io/zent7/vova-medcenter-backend:ecd18145daa41c1dff698c9d438bc1ac313ea3aa@sha256:d11a394d980605acc7a2663abafc35fae3027f33d7716bd63267346f4c377413
     pull_policy: always
     container_name: vova-medcenter-backend
     restart: unless-stopped
@@ -36,7 +36,7 @@ services:
       - "traefik.enable=false"
 
   frontend:
-    image: ghcr.io/zent7/vova-medcenter-frontend:3269ebab0d2f58812e5eacf80bffd635806ced64
+    image: ghcr.io/zent7/vova-medcenter-frontend:ecd18145daa41c1dff698c9d438bc1ac313ea3aa@sha256:3baebe11d95066fd6e38a006081c31fc65c4d56889734392d7eb025e64eac737
     pull_policy: always
     container_name: vova-medcenter-frontend
     restart: unless-stopped
@@ -65,7 +65,7 @@ services:
       frontend:
         condition: service_healthy
     environment:
-      EXPECTED_REVISION: 3269ebab0d2f58812e5eacf80bffd635806ced64
+      EXPECTED_REVISION: ecd18145daa41c1dff698c9d438bc1ac313ea3aa
     command:
       - /bin/sh
       - -ec


### PR DESCRIPTION
## Summary
- pin vova-medcenter frontend/backend images to Zent7/vova-medcenter@ecd18145daa41c1dff698c9d438bc1ac313ea3aa
- include GHCR digests for the immutable image refs
- update release verifier expected revision

## Verification
- docker compose -f komodo/stacks/vova-medcenter/compose.yaml config
- manifest checks for both GHCR images
- app PR checks passed: Publish frontend/backend