### PR TITLE
Add vova-medcenter auto PR workflow

### DIFF
--- a/.github/workflows/vova-medcenter-auto-pr.yml
+++ b/.github/workflows/vova-medcenter-auto-pr.yml
@@ -1,0 +1,39 @@
+name: Vova Medcenter Auto PR
+
+on:
+  push:
+    branches:
+      - automation/vova-medcenter-*
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  open-pr:
+    if: github.repository == 'ravilushqa/homelab'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Open or reuse pull request
+        env:
+          GH_TOKEN: ${{ github.token }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          existing_pr_url="$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url // ""')"
+          if [ -n "$existing_pr_url" ]; then
+            printf '%s\n' "$existing_pr_url"
+            exit 0
+          fi
+
+          short_sha="${BRANCH#automation/vova-medcenter-}"
+          if ! printf '%s\n' "$short_sha" | grep -Eq '^[0-9a-f]{7,40}$'; then
+            short_sha="$(git rev-parse --short HEAD)"
+          fi
+
+          gh pr create \
+            --base main \
+            --head "$BRANCH" \
+            --title "Update vova-medcenter images to $short_sha" \
+            --body "Generated after Zent7/vova-medcenter published backend/frontend images. Updates komodo/stacks/vova-medcenter/compose.yaml."

--- a/.github/workflows/vova-medcenter-auto-pr.yml
+++ b/.github/workflows/vova-medcenter-auto-pr.yml
@@ -21,15 +21,16 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           BRANCH: ${{ github.ref_name }}
         run: |
+          short_sha="${BRANCH#automation/vova-medcenter-}"
+          if ! printf '%s\n' "$short_sha" | grep -Eq '^[0-9a-f]{7,40}$'; then
+            printf 'Skipping non-release branch: %s\n' "$BRANCH"
+            exit 0
+          fi
+
           existing_pr_url="$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url // ""')"
           if [ -n "$existing_pr_url" ]; then
             printf '%s\n' "$existing_pr_url"
             exit 0
-          fi
-
-          short_sha="${BRANCH#automation/vova-medcenter-}"
-          if ! printf '%s\n' "$short_sha" | grep -Eq '^[0-9a-f]{7,40}$'; then
-            short_sha="$(git rev-parse --short HEAD)"
           fi
 
           gh pr create \


### PR DESCRIPTION
## Summary
- add a homelab-side workflow that opens/reuses PRs for branches named `automation/vova-medcenter-<sha>`
- skips non-release branches whose suffix is not a 7-40 char lowercase hex SHA
- lets `Zent7/vova-medcenter` use a repo-scoped SSH deploy key only for pushing update branches
- PR creation happens inside `ravilushqa/homelab` with its own `GITHUB_TOKEN`

## Repo setting
Enabled Actions workflow PR creation for this repo (`can_approve_pull_request_reviews=true`) so `github.token` can create the update PR.

## Verification
- parsed workflow YAML with PyYAML
- ran `git diff --check`
- confirmed PR checks are green after the non-release branch guard

## Rollout order
Merge this before `Zent7/vova-medcenter#38` so pushed update branches can auto-open PRs.
