### PR TITLE
Dispatch vova-medcenter delegated merge after PR creation

### DIFF
--- a/.github/workflows/vova-medcenter-auto-pr.yml
+++ b/.github/workflows/vova-medcenter-auto-pr.yml
@@ -6,6 +6,7 @@ on:
       - automation/vova-medcenter-*
 
 permissions:
+  actions: write
   contents: read
   pull-requests: write
 
@@ -27,14 +28,30 @@ jobs:
             exit 0
           fi
 
-          existing_pr_url="$(gh pr list --head "$BRANCH" --base main --state open --json url --jq '.[0].url // ""')"
-          if [ -n "$existing_pr_url" ]; then
-            printf '%s\n' "$existing_pr_url"
-            exit 0
+          pr_number="$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // ""')"
+
+          if [ -z "$pr_number" ]; then
+            gh pr create \
+              --base main \
+              --head "$BRANCH" \
+              --title "Update vova-medcenter images to $short_sha" \
+              --body "Generated after Zent7/vova-medcenter published backend/frontend images. Updates komodo/stacks/vova-medcenter/compose.yaml."
           fi
 
-          gh pr create \
-            --base main \
-            --head "$BRANCH" \
-            --title "Update vova-medcenter images to $short_sha" \
-            --body "Generated after Zent7/vova-medcenter published backend/frontend images. Updates komodo/stacks/vova-medcenter/compose.yaml."
+          for attempt in {1..10}; do
+            pr_number="$(gh pr list --head "$BRANCH" --base main --state open --json number --jq '.[0].number // ""')"
+            if [ -n "$pr_number" ]; then
+              break
+            fi
+            sleep 2
+          done
+
+          if [ -z "$pr_number" ]; then
+            echo "::error::Could not find open PR for $BRANCH after creation."
+            exit 1
+          fi
+
+          pr_url="$(gh pr view "$pr_number" --json url --jq .url)"
+          printf 'Pull request: %s\n' "$pr_url"
+          printf 'Dispatching vova-medcenter-delegated-merge.yml for PR #%s\n' "$pr_number"
+          gh workflow run vova-medcenter-delegated-merge.yml --ref main -f pr_number="$pr_number"

--- a/.github/workflows/vova-medcenter-delegated-merge.yml
+++ b/.github/workflows/vova-medcenter-delegated-merge.yml
@@ -3,6 +3,11 @@ name: vova-medcenter delegated merge
 on:
   pull_request_target:
     types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Pull request number to validate and merge
+        required: true
 
 permissions:
   contents: write
@@ -14,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       automerge: ${{ steps.scope.outputs.automerge }}
+      pr_url: ${{ steps.scope.outputs.pr_url }}
+      pr_number: ${{ steps.scope.outputs.pr_number }}
     steps:
       - name: Check delegated PR scope
         id: scope
@@ -25,12 +32,30 @@ jobs:
             const generatedLogin = 'github-actions[bot]';
             const generatedBranchPattern = /^automation\/vova-medcenter-([0-9a-f]{7,40})$/;
             const composePath = 'komodo/stacks/vova-medcenter/compose.yaml';
-            const pr = context.payload.pull_request;
+            let pr = context.payload.pull_request;
+
+            if (!pr && context.eventName === 'workflow_dispatch') {
+              const prNumber = Number(core.getInput('pr_number', { required: true }));
+              if (!Number.isInteger(prNumber) || prNumber <= 0) {
+                core.setFailed(`Invalid pr_number input: ${core.getInput('pr_number')}`);
+                return;
+              }
+
+              const response = await github.rest.pulls.get({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: prNumber,
+              });
+              pr = response.data;
+            }
 
             if (!pr) {
-              core.setFailed('This workflow must run on pull_request_target.');
+              core.setFailed('This workflow must run on pull_request_target or workflow_dispatch.');
               return;
             }
+
+            core.setOutput('pr_url', pr.html_url);
+            core.setOutput('pr_number', String(pr.number));
 
             const author = pr.user.login;
             const files = await github.paginate(github.rest.pulls.listFiles, {
@@ -190,13 +215,13 @@ jobs:
           # resulting push does not trigger other workflows. Therefore this job
           # deploys vova-medcenter explicitly after GitHub reports the PR merged.
           GH_TOKEN: ${{ github.token }}
-          PR_URL: ${{ github.event.pull_request.html_url }}
+          PR_URL: ${{ needs.scope.outputs.pr_url }}
         run: gh pr merge "$PR_URL" --squash --delete-branch --auto
 
       - name: Wait for merge to complete
         env:
           GH_TOKEN: ${{ github.token }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_NUMBER: ${{ needs.scope.outputs.pr_number }}
         run: |
           for attempt in {1..60}; do
             STATE=$(gh pr view "$PR_NUMBER" --repo "$GITHUB_REPOSITORY" --json state --jq .state)


### PR DESCRIPTION
## Summary
- add `workflow_dispatch` support to `vova-medcenter-delegated-merge.yml` with a `pr_number` input
- make the delegated merge job fetch and validate dispatched PRs the same way as `pull_request_target` PRs
- have `vova-medcenter-auto-pr.yml` dispatch delegated merge explicitly after creating or finding a generated release PR
- add a retry when looking up the PR number after creation

## Why
GitHub suppresses `pull_request_target` events caused by PRs created with `GITHUB_TOKEN`, so generated PRs did not auto-merge until a later synchronize event. Dispatching the delegated workflow explicitly fixes that.

## Verification
- parsed both workflow YAML files with PyYAML
- ran `git diff --check`
- static check: automerge job no longer references `github.event.pull_request`