### PR TITLE
Fix vova-medcenter dispatch input handling

### DIFF
--- a/.github/workflows/vova-medcenter-delegated-merge.yml
+++ b/.github/workflows/vova-medcenter-delegated-merge.yml
@@ -35,9 +35,10 @@ jobs:
             let pr = context.payload.pull_request;
 
             if (!pr && context.eventName === 'workflow_dispatch') {
-              const prNumber = Number(core.getInput('pr_number', { required: true }));
+              const prNumberInput = context.payload.inputs?.pr_number ?? core.getInput('pr_number');
+              const prNumber = Number(prNumberInput);
               if (!Number.isInteger(prNumber) || prNumber <= 0) {
-                core.setFailed(`Invalid pr_number input: ${core.getInput('pr_number')}`);
+                core.setFailed(`Invalid pr_number input: ${prNumberInput}`);
                 return;
               }
 


### PR DESCRIPTION
## Summary
- fix `workflow_dispatch` PR number handling in `vova-medcenter-delegated-merge.yml`
- read `pr_number` from `context.payload.inputs` inside `actions/github-script`
- keep the existing fallback without `required: true`

## Why
The previous workflow used `core.getInput('pr_number')`, which reads action inputs, not workflow dispatch inputs. Manual dispatch failed with `Input required and not supplied: pr_number`.

## Verification
- parsed workflow YAML with PyYAML
- ran `git diff --check`